### PR TITLE
Adds podsecuritypolicy.yaml template to fluentd chart and according changes

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v1

--- a/charts/fluentd/templates/clusterrole.yaml
+++ b/charts/fluentd/templates/clusterrole.yaml
@@ -16,3 +16,10 @@ rules:
       - list
       - watch
 {{- end -}}
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - {{ template "fluentd.fullname" . }}
+{{- end }}

--- a/charts/fluentd/templates/podsecuritypolicy.yaml
+++ b/charts/fluentd/templates/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "fluentd.fullname" . }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+{{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'hostPath'
+  runAsUser:
+    rule: 'RunAsAny'    
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -17,18 +17,11 @@ serviceAccount:
 rbac:
   create: true
 
-podSecurityContext:
-  {}
-  # fsGroup: 2000
-
-securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Configure podsecuritypolicy
+# Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: true
+  annotations: {}
 
 service:
   type: ClusterIP
@@ -63,7 +56,7 @@ env:
     value: "elasticsearch-master"
   - name: FLUENT_ELASTICSEARCH_PORT
     value: "9200"
-
+    
 envFrom: []
 
 extraVolumes: []


### PR DESCRIPTION
Pod Security Policies enable fine-grained authorization of pod creation and updates.
Some users have psps enforced in their clusters and the chart will not work without them.

`Warning  FailedCreate  4m45s (x18 over 15m)  daemonset-controller  Error creating: pods "fluentd-" is forbidden: unable to validate against any pod security policy`