### PR TITLE
Add variable for additional exposed Ports/Services

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.4.4
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -28,6 +28,7 @@ helm install fluent-bit fluent/fluent-bit
 | config.service | string | `"[SERVICE]\n    Flush 1\n    Daemon Off\n    Log_Level info\n    Parsers_File parsers.conf\n    Parsers_File custom_parsers.conf\n    HTTP_Server On\n    HTTP_Listen 0.0.0.0\n    HTTP_Port 2020\n"` |  |
 | env | list | `[]` |  |
 | envFrom | list | `[]` |  |
+| extraPorts | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -46,6 +46,13 @@ spec:
             - name: http
               containerPort: 2020
               protocol: TCP
+          {{- if .Values.extraPorts }}
+            {{- range .Values.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol }}
+            {{- end }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -15,5 +15,13 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- if .Values.extraPorts }}
+    {{- range .Values.extraPorts }}
+    - name: {{ .name }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+    {{- end }}
+  {{- end }}
   selector:
     {{- include "fluent-bit.selectorLabels" . | nindent 4 }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -71,8 +71,8 @@ env: []
 envFrom: []
 
 extraPorts: []
-#   - port: 1234
-#     containerPort: 5678
+#   - port: 5170
+#     containerPort: 5170
 #     protocol: TCP
 #     name: tcp
 

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -70,6 +70,12 @@ env: []
 
 envFrom: []
 
+extraPorts: []
+#   - port: 1234
+#     containerPort: 5678
+#     protocol: TCP
+#     name: tcp
+
 extraVolumes: []
 
 extraVolumeMounts: []


### PR DESCRIPTION
Since Fluent-bit supports network inputs (TCP and in the future UDP) it makes sense that the helm chart have the ability to expose additional ports at both the daemonset and the service level.

This PR adds an additional variable `extraPorts` which is a list of objects, and the different helm templates will use the variable values to add additional exposed ports to the daemonset and service.

An example usage:
To expose TCP port 1234

The variable `extraPorts` can be set to:
```
extraPorts:
  - name: tcp
    protocol: TCP
    port: 1234
    containerPort: 1234
```

That will result in a service that looks like this:
```
.
.
.
  type: ClusterIP
  ports:
    - port: 2020
      targetPort: http
      protocol: TCP
      name: http
    - name: tcp
      targetPort: http2
      protocol: TCP
      port: 1234
  selector:
    app.kubernetes.io/name: fluent-bit
.
.
.
```

and a daemonset which looks like:
```
.
.
.
          image: "fluent/fluent-bit:1.4.4"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 2020
              protocol: TCP
            - name: tcp
              containerPort: 1234
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /
              port: http
.
.
.
```

The above are a subset of the actual files, but they show how that one variable `extraPorts` can be used to expose additional ports. 



Signed-off-by: Justin Witrick <jwitrick@gmail.com>