### PR TITLE
add lua script to optionally remap metadata keys in kube-logs

### DIFF
--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -5,10 +5,59 @@ metadata:
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:
+{{ if .Values.config.remapMetadataKeysFilter.enabled  }}
+  kubernetes_remap.lua: |-
+    function remap_meta_keys(tag, timestamp, record)
+        if record["kubernetes"] == nil then
+            return 0, 0, 0
+        end
+        remap_keys(record["kubernetes"]["annotations"])
+        remap_keys(record["kubernetes"]["labels"])
+        return 1, timestamp, record
+    end
+
+    function remap_keys(map)
+        if map == nil then
+            return
+        end
+
+        local new_map = {}
+        local changed_keys = {}
+
+        for k, v in pairs(map) do
+            local remapped = k
+
+            {{- range .Values.filter.kubeRemapMetaKeys }}
+            remapped = string.gsub(remapped, {{ .pattern | quote }}, {{ .replacement | quote }})
+            {{- end }}
+
+            if remapped ~= k then
+                new_map[remapped] = v
+                changed_keys[k] = true
+            end
+        end
+
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end   
+{{ end }}
+
   custom_parsers.conf: |
     {{- .Values.config.customParsers | nindent 4 }}
   fluent-bit.conf: |
     {{- .Values.config.service  | nindent 4 }}
     {{- .Values.config.inputs  | nindent 4 }}
     {{- .Values.config.filters  | nindent 4 }}
+{{- if .Values.config.remapMetadataKeysFilter.enabled  }}
+    [FILTER]
+        Name    lua
+        Match   {{ .Values.config.remapMetadataKeysFilter.match }}
+        script  /fluent-bit/scripts/kubernetes_remap.lua
+        call    remap_meta_keys
+{{- end }}
     {{- .Values.config.outputs  | nindent 4 }}

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
         for k, v in pairs(map) do
             local remapped = k
 
-            {{- range .Values.filter.kubeRemapMetaKeys }}
+            {{- range .Values.config.remapMetadataKeysFilter.replaceMap }}
             remapped = string.gsub(remapped, {{ .pattern | quote }}, {{ .replacement | quote }})
             {{- end }}
 

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -70,6 +70,11 @@ spec:
             - name: config
               mountPath: /fluent-bit/etc/custom_parsers.conf
               subPath: custom_parsers.conf
+          {{- if .Values.config.remapMetadataKeysFilter.enabled }}
+            - name: config
+              mountPath: /fluent-bit/scripts/kubernetes_remap.lua
+              subPath: kubernetes_remap.lua
+          {{- end }}
             - name: varlog
               mountPath: /var/log
             - name: varlibdockercontainers

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -120,6 +120,11 @@ config:
         K8S-Logging.Parser On
         K8S-Logging.Exclude On
 
+  # https://github.com/fluent/fluent-bit/issues/1134 
+  remapMetadataKeysFilter:
+    enabled: true
+    match: kube.*
+
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |
     [OUTPUT]

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -125,6 +125,13 @@ config:
     enabled: true
     match: kube.*
 
+    ## List of the respective patterns and replacements for metadata keys replacements
+    ## Pattern must satisfy the Lua spec (see https://www.lua.org/pil/20.2.html)
+    ## Replacement is a plain symbol to replace with
+    replaceMap:
+      - pattern: "[/.]"
+        replacement: "_"
+
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |
     [OUTPUT]


### PR DESCRIPTION
Fixes fluent/fluent-bit#1134 by injecting a lua function from fluent/fluent-bit#1134 (comment) to daemonset pods and using it to replace dots in the keys of kubernetes labels and annotations with underscore to fix data type-related conflicts