### PR TITLE
[fluent-bit] Add extraFiles to add conf to /fluent-bit/etc

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.7.1
+version: 0.7.2
 appVersion: 1.5.6
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -51,6 +51,11 @@ containers:
       - name: config
         mountPath: /fluent-bit/etc/custom_parsers.conf
         subPath: custom_parsers.conf
+    {{- range $key, $val := .Values.config.extraFiles }}
+      - name: config
+        mountPath: /fluent-bit/etc/{{ $key }}
+        subPath: {{ $key }}
+    {{- end }}
     {{- if eq .Values.kind "DaemonSet" }}
       - name: varlog
         mountPath: /var/log

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -12,3 +12,7 @@ data:
     {{- .Values.config.inputs  | nindent 4 }}
     {{- .Values.config.filters  | nindent 4 }}
     {{- .Values.config.outputs  | nindent 4 }}
+  {{- range $key, $val := .Values.config.extraFiles }}
+  {{ $key }}: |
+    {{- $val | nindent 4 }}
+  {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -156,3 +156,5 @@ config:
         Time_Keep Off
         Time_Key time
         Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+  extraFiles: {}


### PR DESCRIPTION
This allows adding more files to /fluent-bit/etc without having to externally define volume and volume mounts. Instead, we can add arbitrary files and file names by providing key/val pairs in the `.Values.config.extraFiles` variable in values.yaml. The key becomes the filename, the value becomes the file content.

This is useful for cases where someone needs to add a `Streams_File` or `Plugins_File` inside the `[SERVICE]` section (like I do).

In theory, it might be nice to move custom_parsers.conf to this structure, but I did not touch that for backwards compatibility.