### PR TITLE
Add ability for custom dnsConfig

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.7.12
+version: 0.7.13
 appVersion: 1.6.8
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -9,6 +9,8 @@ priorityClassName: {{ .Values.priorityClassName }}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 securityContext:
   {{- toYaml .Values.podSecurityContext | nindent 2 }}
+dnsConfig:
+  {{- toYaml .Values.podDnsConfig | nindent 2 }}
 containers:
   - name: {{ .Chart.Name }}
     securityContext:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -9,8 +9,10 @@ priorityClassName: {{ .Values.priorityClassName }}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 securityContext:
   {{- toYaml .Values.podSecurityContext | nindent 2 }}
+{{- with .Values.dnsConfig }}
 dnsConfig:
-  {{- toYaml .Values.podDnsConfig | nindent 2 }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 containers:
   - name: {{ .Chart.Name }}
     securityContext:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -29,7 +29,16 @@ podSecurityPolicy:
 podSecurityContext:
   {}
   # fsGroup: 2000
-
+podDnsConfig: {}
+  # nameservers:
+  #   - 1.2.3.4
+  # searches:
+  #   - ns1.svc.cluster-domain.example
+  #   - my.dns.search.suffix
+  # options:
+  #   - name: ndots
+#     value: "2"
+#   - name: edns0
 securityContext:
   {}
   # capabilities:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -29,7 +29,7 @@ podSecurityPolicy:
 podSecurityContext:
   {}
   # fsGroup: 2000
-podDnsConfig: {}
+dnsConfig: {}
   # nameservers:
   #   - 1.2.3.4
   # searches:


### PR DESCRIPTION
**What this PR does / why we need it:**
Adding possibility to set a custom dnsConfig for the pods. Pod's DNS Config field enable users more control on the DNS settings for the pods.

**Use-case example**
Fluent-bit pods /etc/resolv.conf ndots:5 (default) and output Elasticsearch external domain example.elastic.com, syscall will try to resolve it sequentially going through all local search domains first and then resolve the absolute name only at last, which puts load on the DNS resolver and impacts the performance of the applications. Tuning dnsConfig for Fluent-bit pod allows us to avoid such scenarios and resolve the absolute name at first and cache the positive response.


Similar work done in the past in previous stable repository. [ref.](https://github.com/helm/charts/pull/22419)