### PR TITLE
[fluent-bit]: add prometheusrule, networkpolicy and use tpl in configmap

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.8.3
+version: 0.9.0
 appVersion: 1.6.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -20,4 +20,6 @@ maintainers:
     email: towmeykaw@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - Add Grafana dashboard config map for sidecar
+    - add prometheusrule
+    - add networkpolicy ingress support
+    - use tpl in configmap

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:
   custom_parsers.conf: |
-    {{- .Values.config.customParsers | nindent 4 }}
+    {{- (tpl .Values.config.customParsers $) | nindent 4 }}
   fluent-bit.conf: |
-    {{- .Values.config.service  | nindent 4 }}
-    {{- .Values.config.inputs  | nindent 4 }}
-    {{- .Values.config.filters  | nindent 4 }}
-    {{- .Values.config.outputs  | nindent 4 }}
+    {{- (tpl .Values.config.service $)  | nindent 4 }}
+    {{- (tpl .Values.config.inputs $)  | nindent 4 }}
+    {{- (tpl .Values.config.filters $)  | nindent 4 }}
+    {{- (tpl .Values.config.outputs $)  | nindent 4 }}
 {{- end -}}

--- a/charts/fluent-bit/templates/networkpolicy.yaml
+++ b/charts/fluent-bit/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: "networking.k8s.io/v1"
+kind: "NetworkPolicy"
+metadata:
+  name: {{ include "fluent-bit.fullname" . | quote }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - "Ingress"
+  podSelector:
+    matchLabels:
+      {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+  ingress:
+    {{- with .Values.networkPolicy.ingress }}
+    - from:
+        {{- with .from }}{{- . | toYaml | nindent 8 }}{{- else }} []{{- end }}
+      ports:
+        - protocol: "TCP"
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/fluent-bit/templates/prometheusrule.yaml
+++ b/charts/fluent-bit/templates/prometheusrule.yaml
@@ -1,0 +1,20 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  {{- with .Values.prometheusRule.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+  {{- if .Values.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.prometheusRule.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.prometheusRule.rules }}
+  groups:
+  - name: {{ template "fluent-bit.name" . }}
+    rules: {{- toYaml .Values.prometheusRule.rules | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -130,6 +130,11 @@ updateStrategy: {}
 # Make use of a pre-defined configmap instead of the one templated here
 existingConfigMap: ""
 
+networkPolicy:
+  enabled: false
+  # ingress:
+  #   from: []
+
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:
   service: |

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -73,6 +73,22 @@ serviceMonitor:
   # selector:
   #  prometheus: my-prometheus
 
+prometheusRule:
+  enabled: false
+  # namespace: ""
+  # additionnalLabels: {}
+  # rules:
+  # - alert: NoOutputBytesProcessed
+  #   expr: rate(fluentbit_output_proc_bytes_total[5m]) == 0
+  #   annotations:
+  #     message: |
+  #       Fluent Bit instance {{ $labels.instance }}'s output plugin {{ $labels.name }} has not processed any
+  #       bytes for at least 15 minutes.
+  #     summary: No Output Bytes Processed
+  #   for: 15m
+  #   labels:
+  #     severity: critical
+
 dashboards:
   enabled: false
   labelKey: grafana_dashboard

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -141,7 +141,7 @@ config:
         Parsers_File custom_parsers.conf
         HTTP_Server On
         HTTP_Listen 0.0.0.0
-        HTTP_Port 2020
+        HTTP_Port {{ .Values.service.port }}
 
   ## https://docs.fluentbit.io/manual/pipeline/inputs
   inputs: |


### PR DESCRIPTION
Hi,

I know that this PR embed more than one modification, so should I split it on three different one, or can I keep all changes on this one?

## What changed?
1. **Add networkPolicy**:  be able to limit access to metrics endpoint only to prometheus instances for exemple

2. **Add PrometheusRule**: embed Alerting in the chart instead of putting all rules on a single place (only if prometheus CRDs are installed)

3. **Be able to customize configurations across environments**: We have different environments with the same configuration except Cluster depending ones (environment, uri, ...). 
This change allows to use values in configuration
```yaml
config:
  service: |
    [SERVICE]
        Flush 1
        Daemon Off
        Log_Level info
        Parsers_File parsers.conf
        Parsers_File custom_parsers.conf
        HTTP_Server On
        HTTP_Listen 0.0.0.0
        HTTP_Port {{ .Values.service.port }}
```

## Chart version
I changed version in `Chart.yaml` with version `0.9.0` and I filled in `artifacthub.io/changes` annotation