### PR TITLE
feat(fluent-bit): add custom annotations to dashboards configmap

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.9.0
+version: 0.10.0
 appVersion: 1.6.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -20,6 +20,4 @@ maintainers:
     email: towmeykaw@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - add prometheusrule
-    - add networkpolicy ingress support
-    - use tpl in configmap
+    - add custom annotations on dashboards configmap

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dashboard-{{ trimSuffix ".json" (base $path) }}
+  {{- with $.Values.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{- end }}
   labels:
     {{- include "fluent-bit.labels" $ | nindent 4 }}
     {{ $.Values.dashboards.labelKey }}: "1"

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -92,6 +92,8 @@ prometheusRule:
 dashboards:
   enabled: false
   labelKey: grafana_dashboard
+  annotations: {}
+
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
Signed-off-by: Alexis Martinier <a.martinier@gmail.com>

This change allows to specify annotations on dashboards configmap

**use case**:  
if grafana sidecar is configured with `sidecar.dashboards.folderAnnotation: grafana/folder` ([grafana configuration](https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#configuration)), we can change the dashboard folder
```yaml
dashboard:
  enabled: true
  labelKey: grafana_dashboard
  annotations:
    grafana/folder: logging
```