### PR TITLE
[fluent-bit] Add upstream server option to configmap

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.10.0
+version: 0.10.1
 appVersion: 1.6.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -13,4 +13,6 @@ data:
     {{- (tpl .Values.config.inputs $)  | nindent 4 }}
     {{- (tpl .Values.config.filters $)  | nindent 4 }}
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
+  upstream.conf: |
+    {{- (tpl .Values.config.upstream $)  | nindent 4 }}
 {{- end -}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -217,3 +217,26 @@ config:
         Time_Keep Off
         Time_Key time
         Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+  ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/upstream-servers
+  upstream: |
+    [UPSTREAM]
+        name       forward-balancing
+
+    [NODE]
+        name       node-1
+        host       127.0.0.1
+        port       43000
+
+    [NODE]
+        name       node-2
+        host       127.0.0.1
+        port       44000
+
+    [NODE]
+        name       node-3
+        host       127.0.0.1
+        port       45000
+        tls        on
+        tls.verify off
+        shared_key secret


### PR DESCRIPTION
This should add an [upstream server](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/upstream-servers) option to the configmap.

This is my current working example.

``` yaml
apiVersion: v1
kind: ConfigMap
metadata:
    name: fluent-bit-config
    namespace: logging
    labels:
        k8s-app: fluent-bit
data:
    fluent-bit.conf: |

    ...
    
        [OUTPUT]
            Name        forward
            Match       foo.*
            Upstream    upstream.conf
            Port        23000

    upstream.conf: |
        [UPSTREAM]
            name   foo-logs
        [NODE]
            name    foo-logs
            host   foo-logs.mydomain.com
            port    23000
            tls         on
            tls.verify  on
            tls.crt_file /etc/tls/tls.crt
            tls.key_file /etc/tls/tls.key
```

Signed-off-by: Matt Mencel <matt@techminer.net>