### PR TITLE
added the ability to add custom lua scripts to the values file

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.10.1
+version: 0.11.1
 appVersion: 1.6.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.10.0
+version: 0.10.1
 appVersion: 1.6.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -55,6 +55,11 @@ containers:
       - name: config
         mountPath: /fluent-bit/etc/custom_parsers.conf
         subPath: custom_parsers.conf
+    {{- range $key, $value := .Values.extraLuaScripts }}
+      - name: config
+        mountPath: /fluent-bit/scripts/{{ $key }}
+        subPath: script-{{ $key }}
+    {{- end }}
     {{- if eq .Values.kind "DaemonSet" }}
       - name: varlog
         mountPath: /var/log

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -55,10 +55,10 @@ containers:
       - name: config
         mountPath: /fluent-bit/etc/custom_parsers.conf
         subPath: custom_parsers.conf
-    {{- range $key, $value := .Values.extraLuaScripts }}
-      - name: config
+    {{- range $key, $value := .Values.luaScripts }}
+      - name: luascripts
         mountPath: /fluent-bit/scripts/{{ $key }}
-        subPath: script-{{ $key }}
+        subPath: {{ $key }}
     {{- end }}
     {{- if eq .Values.kind "DaemonSet" }}
       - name: varlog
@@ -77,6 +77,11 @@ volumes:
   - name: config
     configMap:
       name: {{ if .Values.existingConfigMap }}{{ .Values.existingConfigMap }}{{- else }}{{ include "fluent-bit.fullname" . }}{{- end }}
+{{- if gt (len .Values.luaScripts) 0 }}
+  - name: luascripts
+    configMap:
+      name: {{ include "fluent-bit.fullname" . }}-luascripts
+{{- end }}
 {{- if eq .Values.kind "DaemonSet" }}
   - name: varlog
     hostPath:

--- a/charts/fluent-bit/templates/configmap-luascripts.yaml
+++ b/charts/fluent-bit/templates/configmap-luascripts.yaml
@@ -1,0 +1,12 @@
+{{- if gt (len .Values.luaScripts) 0 -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}-luascripts
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+data:
+  {{ range $key, $value := .Values.luaScripts }}
+  {{ $key }}: {{ $value | quote }}
+  {{ end }}
+{{- end -}}

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -6,9 +6,6 @@ metadata:
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:
-{{ range $key, $value := .Values.extraLuaScripts }}
-  script-{{ $key }}: {{ $value | quote }}
-{{ end }}
   custom_parsers.conf: |
     {{- (tpl .Values.config.customParsers $) | nindent 4 }}
   fluent-bit.conf: |

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:
+{{ range $key, $value := .Values.extraLuaScripts }}
+  script-{{ $key }}: {{ $value | quote }}
+{{ end }}
   custom_parsers.conf: |
     {{- (tpl .Values.config.customParsers $) | nindent 4 }}
   fluent-bit.conf: |

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -140,6 +140,8 @@ extraVolumes: []
 
 extraVolumeMounts: []
 
+extraLuaScripts: {}
+
 updateStrategy: {}
   # type: RollingUpdate
   # rollingUpdate:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -140,8 +140,6 @@ extraVolumes: []
 
 extraVolumeMounts: []
 
-extraLuaScripts: {}
-
 updateStrategy: {}
   # type: RollingUpdate
   # rollingUpdate:
@@ -154,6 +152,8 @@ networkPolicy:
   enabled: false
   # ingress:
   #   from: []
+
+luaScripts: {}
 
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:


### PR DESCRIPTION
This PR allows us to add an unlimited number of lua scripts to the extraLuaScripts section in the values file. The scripts will be mounted to the /fluent-bit/scripts folder.
To use the script, you need to add a section with a lua filter that uses this script. For example:

[FILTER]
    Name lua
    Match *
    script /fluent-bit/scripts/<script_name>.lua
    call <lua_function>