### PR TITLE
[fluent-bit] Bump appVersion to 1.7.0

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.12.1
-appVersion: 1.6.10
+version: 0.12.2
+appVersion: 1.7.0
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:


### PR DESCRIPTION
- Bump appVersion to latest fluent-bit version ([1.7.0](https://fluentbit.io/announcements/v1.7.0))
- Bump chart version to 0.12.2