### PR TITLE
[fluent-bit] Allow user-defined sidecar containers

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.12.3
+version: 0.13.0
 appVersion: 1.7.1
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -73,6 +73,9 @@ containers:
     {{- if .Values.extraVolumeMounts }}
       {{- toYaml .Values.extraVolumeMounts | nindent 6 }}
     {{- end }}
+  {{- if .Values.extraContainers }}
+    {{- toYaml .Values.extraContainers | nindent 2 }}
+  {{- end }}
 volumes:
   - name: config
     configMap:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -130,6 +130,11 @@ env: []
 
 envFrom: []
 
+extraContainers: []
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
 extraPorts: []
 #   - port: 5170
 #     containerPort: 5170


### PR DESCRIPTION
`extraContainers` property accepts an array of Pod containers