### PR TITLE
[fluentd] extend servicemonitor with metric relabel config

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: v1.12.0
 icon: https://www.fluentd.org/assets/img/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/servicemonitor.yaml
+++ b/charts/fluentd/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | default "fluentd" }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | default .Release.Name }}
   endpoints:
     - port: metrics
       path: /metrics

--- a/charts/fluentd/templates/servicemonitor.yaml
+++ b/charts/fluentd/templates/servicemonitor.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | default "fluentd" }}
   endpoints:
     - port: metrics
       path: /metrics
@@ -21,6 +22,14 @@ spec:
       {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+{{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ tpl (toYaml .Values.metrics.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.metrics.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   {{- if .Values.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector:
     {{ toYaml .Values.metrics.serviceMonitor.namespaceSelector | indent 4 -}}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -135,9 +135,9 @@ metrics:
       release: prometheus-operator
     namespace: ""
     namespaceSelector: {}
-    ##	metric relabel configs to apply to samples before ingestion.
+    ## metric relabel configs to apply to samples before ingestion.
     metricRelabelings: []
-    ##	relabel configs to apply to samples before ingestion.
+    ## relabel configs to apply to samples before ingestion.
     relabelings: []
     # jobLabel: fluentd
     # scrapeInterval: 30s

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -136,9 +136,24 @@ metrics:
     namespace: ""
     namespaceSelector: {}
     ## metric relabel configs to apply to samples before ingestion.
+    ##
     metricRelabelings: []
-    ## relabel configs to apply to samples before ingestion.
+    # - sourceLabels: [__name__]
+    #   separator: ;
+    #   regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
+    #   replacement: $1
+    #   action: drop
+    ## relabel configs to apply to samples after ingestion.
+    ##
     relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+    ## Additional serviceMonitor config
+    ##
     # jobLabel: fluentd
     # scrapeInterval: 30s
     # scrapeTimeout: 5s

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -135,6 +135,11 @@ metrics:
       release: prometheus-operator
     namespace: ""
     namespaceSelector: {}
+    ##	metric relabel configs to apply to samples before ingestion.
+    metricRelabelings: []
+    ##	relabel configs to apply to samples before ingestion.
+    relabelings: []
+    # jobLabel: fluentd
     # scrapeInterval: 30s
     # scrapeTimeout: 5s
     # honorLabels: true


### PR DESCRIPTION
Hi
this PR extend to servicemonitor to allow custom
* metricRelabelings 
* relabelings:

example add the nodename label to fluentd metrics
```
    relabelings:
    - action: replace
      sourceLabels:
      - __meta_kubernetes_pod_node_name
      targetLabel: nodename
```

The joblabel is defaulting to `.Release.Name` if not otherwise set. 