### PR TITLE
[fluentd] fixed prometheusrule template injection

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: v1.12.0
 icon: https://www.fluentd.org/assets/img/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/prometheusrules.yaml
+++ b/charts/fluentd/templates/prometheusrules.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
   {{- with .Values.metrics.prometheusRule.rules }}
   groups:
-  - name: {{ template "fluentd.fullname" . }}
-    rules: {{- toYaml . | nindent 4 }}
+  - name: {{ template "fluentd.fullname" $ }}
+    rules:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -164,6 +164,24 @@ metrics:
     additionalLabels: {}
     namespace: ""
     rules: []
+    # - alert: FluentdDown
+    #   expr: up{job="fluentd"} == 0
+    #   for: 5m
+    #   labels:
+    #     context: fluentd
+    #     severity: warning
+    #   annotations:
+    #     summary: "Fluentd Down"
+    #     description: "{{ $labels.pod }} on {{ $labels.nodename }} is down"
+    # - alert: FluentdScrapeMissing
+    #   expr: absent(up{job="fluentd"} == 1)
+    #   for: 15m
+    #   labels:
+    #     context: fluentd
+    #     severity: warning
+    #   annotations:
+    #     summary: "Fluentd Scrape Missing"
+    #     description: "Fluentd instance has disappeared from Prometheus target discovery"
 
 ## Grafana Monitoring Dashboard
 ##


### PR DESCRIPTION
When prometheusrule is enable i got the following error:
```
Error: template: fluentd/templates/_helpers.tpl:15:14: executing "fluentd.fullname" at <.Values.fullnameOverride>: can't evaluate field Values in type []interface {}
helm.go:81: [debug] template: fluentd/templates/_helpers.tpl:15:14: executing "fluentd.fullname" at <.Values.fullnameOverride>: can't evaluate field Values in type []interface {}
```

This PR fix this issue.
I also added some example alerts