### PR TITLE
[fluent-bit] Add support exec livenessProbe

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.15.1
+version: 0.15.2
 appVersion: 1.7.2
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -49,10 +49,20 @@ containers:
     {{- if .Values.livenessProbe }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
+    {{- else }}
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
     {{- end }}
     {{- if .Values.readinessProbe }}
     readinessProbe:
       {{- toYaml .Values.readinessProbe | nindent 6 }}
+    {{- else }}
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
     {{- end }}
     resources:
       {{- toYaml .Values.resources | nindent 6 }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -96,15 +96,15 @@ dashboards:
   annotations: {}
 
 
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
+livenessProbe: {}
+  # httpGet:
+  #   path: /
+  #   port: http
 
 readinessProbe:
-  httpGet:
-    path: /
-    port: http
+  # httpGet:
+  #   path: /
+  #   port: http
 
 resources:
   {}


### PR DESCRIPTION
### Issue

When you use the fluent-bit helm chart as a sub-chart and you set a custom livenessProbe that is not httpGet based, a duplicate probe gets set.

```
livenessProbe:
  exec:
    command:
      - powershell
      - Get-Process
      - ProcessName
      - fluent-bit
  httpGet:
    path: /
    port: http
```

Normally you would just set httpGet to be null in the parent chart, and it would override the value. However, there is an open issue with helm [helm/helm/issues/9136](https://github.com/helm/helm/issues/9136) where that functionality is not working.

I'm looking to use an exec livenessProbe, so if there is a preferred implementation I can adjust my pr.

This if/else way allows you to over write the httpGet probe.