### PR TITLE
[fluent-bit] Support the initContainers from the values.yaml

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.15.5
+version: 0.15.6
 appVersion: 1.7.3
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -15,7 +15,7 @@ dnsConfig:
 {{- end }}
 {{ if .Values.initContainers }}
 initContainers:
-  {{ toYaml .Values.initContainers | nindent 2 }}
+  {{- toYaml .Values.initContainers | nindent 2 }}
 {{- end }}
 containers:
   - name: {{ .Chart.Name }}

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -13,7 +13,7 @@ securityContext:
 dnsConfig:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{ if .Values.initContainers }}
+{{- if .Values.initContainers }}
 initContainers:
   {{- toYaml .Values.initContainers | nindent 2 }}
 {{- end }}

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -13,6 +13,10 @@ securityContext:
 dnsConfig:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{ if .Values.initContainers }}
+initContainers:
+{{ toYaml .Values.initContainers | indent 2 }}
+{{- end }}
 containers:
   - name: {{ .Chart.Name }}
     securityContext:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -15,7 +15,7 @@ dnsConfig:
 {{- end }}
 {{ if .Values.initContainers }}
 initContainers:
-{{ toYaml .Values.initContainers | indent 2 }}
+  {{ toYaml .Values.initContainers | nindent 2 }}
 {{- end }}
 containers:
   - name: {{ .Chart.Name }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -260,3 +260,8 @@ daemonSetVolumeMounts:
 args: []
 
 command: []
+
+initContainers: []
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']


### PR DESCRIPTION
This patch make the Charts to support the initContainers, user can dynamically add initContainers via the values.yaml.


Original issue: #81 