### PR TITLE
[fluent-bit] Add release name in dashboard name

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.15.4
+version: 0.15.5
 appVersion: 1.7.3
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dashboard-{{ trimSuffix ".json" (base $path) }}
+  name: {{ include "fluent-bit.fullname" . }}-dashboard-{{ trimSuffix ".json" (base $path) }}
   {{- with $.Values.dashboards.annotations }}
   annotations:
     {{- toYaml . | nindent 4 -}}


### PR DESCRIPTION
It allows to deploy the chart in the same namespace more than once without conflicts.