### PR TITLE
[fluent-bit] Add pods/logs to the allowed resources list

### DIFF
--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -10,6 +10,7 @@ rules:
       - ""
     resources:
       - pods
+      - pods/logs
       - namespaces
     verbs:
       - get


### PR DESCRIPTION
The `pods/logs` should be part of the resources list when creating a new cluster role. Otherwise, the newly created service account is not able to access the logs of the pods. That being said, the Fluent Bit integration doesn't work, and the logs are not sent to the specified destination.