### PR TITLE
[fluent-bit] Add optional hostAliases

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.15.8
+version: 0.15.10
 appVersion: 1.7.4
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -13,6 +13,10 @@ securityContext:
 dnsConfig:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.hostAliases }}
+hostAliases:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- if .Values.initContainers }}
 initContainers:
   {{- toYaml .Values.initContainers | nindent 2 }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -46,6 +46,13 @@ dnsConfig: {}
   #   - name: ndots
 #     value: "2"
 #   - name: edns0
+
+hostAliases: []
+  # - ip: "1.2.3.4"
+  #   hostnames:
+  #   - "foo.local"
+  #   - "bar.local"
+
 securityContext:
   {}
   # capabilities:


### PR DESCRIPTION
Signed-off-by: Salicorne <timothee.raboeuf@gmail.com>

Since fluent-bit does not support the IP Address certificate SubjectAlternateName when validating a remote certificate in the HTTP output, it can be useful to provide custom hostAliases in the Helm chart to match a DNS SAN of the certificate. 