### PR TITLE
[fluent-bit] Support v1.8

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.1
+          version: v3.6.3
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
@@ -24,9 +24,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          version: v3.3.0
+        uses: helm/chart-testing-action@v2.1.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -40,7 +38,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,10 +22,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.1
+          version: v3.6.3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.2.1
         with:
           charts_dir: charts
         env:

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.15.15
-appVersion: 1.7.9
+version: 0.16.0
+appVersion: 1.8.2
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -20,4 +20,15 @@ maintainers:
     email: towmeykaw@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - Upgrade fluent-bit image to v1.7.9
+    - kind: changed
+      description: Upgrade fluent-bit image to v1.8.2.
+    - kind: changed
+      description: Use new health check endpoint for readiness.
+    - kind: changed
+      description: Use liveness and rediness config from values, this means setting httpGet: {} if you want to use exec.
+    - kind: added
+      description: Multiline docker and cri logs in the default tail input.
+    - kind: added
+      description: Support for Use_Kubelet true in the Kubernetes filter config by enabling setting rbac.nodeAccess: true, hostNetwork: true and dnsPolicy: ClusterFirstWithHostNet.
+    - kind: added
+      description: Customisable log level via logLevel value.

--- a/charts/fluent-bit/ci/ci-values.yaml
+++ b/charts/fluent-bit/ci/ci-values.yaml
@@ -1,0 +1,1 @@
+logLevel: debug

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -9,6 +9,8 @@ priorityClassName: {{ .Values.priorityClassName }}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 securityContext:
   {{- toYaml .Values.podSecurityContext | nindent 2 }}
+hostNetwork: {{ .Values.hostNetwork }}
+dnsPolicy: {{ .Values.dnsPolicy }}
 {{- with .Values.dnsConfig }}
 dnsConfig:
   {{- toYaml . | nindent 2 }}
@@ -54,24 +56,10 @@ containers:
         protocol: {{ .protocol }}
       {{- end }}
     {{- end }}
-    {{- if .Values.livenessProbe }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
-    {{- else }}
-    livenessProbe:
-      httpGet:
-        path: /
-        port: http
-    {{- end }}
-    {{- if .Values.readinessProbe }}
     readinessProbe:
       {{- toYaml .Values.readinessProbe | nindent 6 }}
-    {{- else }}
-    readinessProbe:
-      httpGet:
-        path: /
-        port: http
-    {{- end }}
     resources:
       {{- toYaml .Values.resources | nindent 6 }}
     volumeMounts:

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -9,8 +9,12 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
       - namespaces
+      - pods
+      {{- if .Values.rbac.nodeAccess }}
+      - nodes
+      - nodes/proxy
+      {{- end }}
     verbs:
       - get
       - list

--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -17,7 +17,7 @@ spec:
     - ALL
   volumes:
     - '*'
-  hostNetwork: false
+  hostNetwork: {{ .Value.hostNetwork }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -8,8 +8,9 @@ replicaCount: 1
 
 image:
   repository: fluent/fluent-bit
+  # Overrides the image tag whose default is {{ .Chart.AppVersion }}
+  tag: ""
   pullPolicy: Always
-  # tag:
 
 testFramework:
   image:
@@ -28,99 +29,98 @@ serviceAccount:
 
 rbac:
   create: true
+  nodeAccess: false
 
 podSecurityPolicy:
   create: false
   annotations: {}
 
-podSecurityContext:
-  {}
-  # fsGroup: 2000
+podSecurityContext: {}
+#   fsGroup: 2000
+
+hostNetwork: false
+dnsPolicy: ClusterFirst
+
 dnsConfig: {}
-  # nameservers:
-  #   - 1.2.3.4
-  # searches:
-  #   - ns1.svc.cluster-domain.example
-  #   - my.dns.search.suffix
-  # options:
-  #   - name: ndots
-#     value: "2"
-#   - name: edns0
+#   nameservers:
+#     - 1.2.3.4
+#   searches:
+#     - ns1.svc.cluster-domain.example
+#     - my.dns.search.suffix
+#   options:
+#     - name: ndots
+#       value: "2"
+#     - name: edns0
 
 hostAliases: []
-  # - ip: "1.2.3.4"
-  #   hostnames:
-  #   - "foo.local"
-  #   - "bar.local"
+#   - ip: "1.2.3.4"
+#     hostnames:
+#     - "foo.local"
+#     - "bar.local"
 
-securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext: {}
+#   capabilities:
+#     drop:
+#     - ALL
+#   readOnlyRootFilesystem: true
+#   runAsNonRoot: true
+#   runAsUser: 1000
 
 service:
   type: ClusterIP
   port: 2020
-  labels:
-    {}
-  annotations:
-    {}
-    # prometheus.io/path: "/api/v1/metrics/prometheus"
-    # prometheus.io/port: "2020"
-    # prometheus.io/scrape: "true"
+  labels: {}
+  annotations: {}
+#   prometheus.io/path: "/api/v1/metrics/prometheus"
+#   prometheus.io/port: "2020"
+#   prometheus.io/scrape: "true"
 
 serviceMonitor:
   enabled: false
-  # namespace: monitoring
-  # interval: 10s
-  # scrapeTimeout: 10s
-  # selector:
-  #  prometheus: my-prometheus
+#   namespace: monitoring
+#   interval: 10s
+#   scrapeTimeout: 10s
+#   selector:
+#    prometheus: my-prometheus
 
 prometheusRule:
   enabled: false
-  # namespace: ""
-  # additionnalLabels: {}
-  # rules:
-  # - alert: NoOutputBytesProcessed
-  #   expr: rate(fluentbit_output_proc_bytes_total[5m]) == 0
-  #   annotations:
-  #     message: |
-  #       Fluent Bit instance {{ $labels.instance }}'s output plugin {{ $labels.name }} has not processed any
-  #       bytes for at least 15 minutes.
-  #     summary: No Output Bytes Processed
-  #   for: 15m
-  #   labels:
-  #     severity: critical
+#   namespace: ""
+#   additionnalLabels: {}
+#   rules:
+#   - alert: NoOutputBytesProcessed
+#     expr: rate(fluentbit_output_proc_bytes_total[5m]) == 0
+#     annotations:
+#       message: |
+#         Fluent Bit instance {{ $labels.instance }}'s output plugin {{ $labels.name }} has not processed any
+#         bytes for at least 15 minutes.
+#       summary: No Output Bytes Processed
+#     for: 15m
+#     labels:
+#       severity: critical
 
 dashboards:
   enabled: false
   labelKey: grafana_dashboard
   annotations: {}
 
-
-livenessProbe: {}
-  # httpGet:
-  #   path: /
-  #   port: http
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
 
 readinessProbe:
-  # httpGet:
-  #   path: /
-  #   port: http
+  httpGet:
+    path: /api/v1/health
+    port: http
 
-resources:
-  {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi
 
 nodeSelector: {}
 
@@ -139,9 +139,9 @@ env: []
 envFrom: []
 
 extraContainers: []
-  # - name: do-something
-  #   image: busybox
-  #   command: ['do', 'something']
+#   - name: do-something
+#     image: busybox
+#     command: ['do', 'something']
 
 extraPorts: []
 #   - port: 5170
@@ -154,17 +154,17 @@ extraVolumes: []
 extraVolumeMounts: []
 
 updateStrategy: {}
-  # type: RollingUpdate
-  # rollingUpdate:
-  #   maxUnavailable: 1
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 1
 
 # Make use of a pre-defined configmap instead of the one templated here
 existingConfigMap: ""
 
 networkPolicy:
   enabled: false
-  # ingress:
-  #   from: []
+#   ingress:
+#     from: []
 
 luaScripts: {}
 
@@ -172,21 +172,22 @@ luaScripts: {}
 config:
   service: |
     [SERVICE]
-        Flush 1
         Daemon Off
-        Log_Level info
+        Flush 1
+        Log_Level {{ .Values.logLevel }}
         Parsers_File parsers.conf
         Parsers_File custom_parsers.conf
         HTTP_Server On
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.service.port }}
+        Health_Check On
 
   ## https://docs.fluentbit.io/manual/pipeline/inputs
   inputs: |
     [INPUT]
         Name tail
         Path /var/log/containers/*.log
-        Parser docker
+        multiline.parser docker, cri
         Tag kube.*
         Mem_Buf_Limit 5MB
         Skip_Long_Lines On
@@ -269,6 +270,8 @@ args: []
 command: []
 
 initContainers: []
-  # - name: do-something
-  #   image: busybox
-  #   command: ['do', 'something']
+#   - name: do-something
+#     image: busybox
+#     command: ['do', 'something']
+
+logLevel: info


### PR DESCRIPTION
This PR adds support to Fluent Bit v1.8 with the following chart changes as well as tidying up the comments in values.yaml for automatic formatting and updating the GitHub actions.

- Upgrade fluent-bit image to v1.8.1.
- Use new health check endpoint for readiness.
- Use liveness and rediness config from values, this means setting `httpGet: {}` if you want to use exec.
- Multiline docker and cri logs in the default tail input.
- Support for the `Use_Kubelet true` in the Kubernetes filter config by enabling setting `rbac.nodeAccess: true`, `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`.
- Customisable log level via `logLevel` value.

Fixes #135, fixes #119.