### PR TITLE
[fluentd] add K8S_NODE_NAME env variable for Kubernetes metadata plugin

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: v1.12.0
 icon: https://www.fluentd.org/assets/img/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -133,6 +133,10 @@ podLabels: {}
 env:
 - name: "FLUENTD_CONF"
   value: "../../etc/fluent/fluent.conf"
+- name: K8S_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
   # - name: FLUENT_ELASTICSEARCH_HOST
   #   value: "elasticsearch-master"
   # - name: FLUENT_ELASTICSEARCH_PORT


### PR DESCRIPTION
Adds the `K8S_NODE_NAME` env  variable as suggested here: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes