### PR TITLE
feat: Enable configuration of rollout strategy

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.16.1
+version: 0.16.2
 appVersion: 1.8.2
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -28,8 +28,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluent-bit.pod" . | nindent 6 }}
-    {{- with .Values.updateStrategy }}
-    updateStrategy:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -28,4 +28,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluent-bit.pod" . | nindent 6 }}
+    {{- with .Values.updateStrategy }}
+    updateStrategy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -29,4 +29,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluent-bit.pod" . | nindent 6 }}
+    {{- with .Values.updateStrategy }}
+    strategy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -29,8 +29,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluent-bit.pod" . | nindent 6 }}
-    {{- with .Values.updateStrategy }}
-    strategy:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -114,6 +114,11 @@ readinessProbe:
     path: /api/v1/health
     port: http
 
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
 resources: {}
 #   limits:
 #     cpu: 100m

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: v1.12.0
 icon: https://www.fluentd.org/assets/img/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -22,4 +22,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluentd.pod" . | nindent 6 }}
+    {{- with .Values.updateStrategy }}
+    updateStrategy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -22,8 +22,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluentd.pod" . | nindent 6 }}
-    {{- with .Values.updateStrategy }}
-    updateStrategy:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/fluentd/templates/deployment.yaml
+++ b/charts/fluentd/templates/deployment.yaml
@@ -23,4 +23,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluentd.pod" . | nindent 6 }}
+    {{- with .Values.updateStrategy }}
+    strategy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/fluentd/templates/deployment.yaml
+++ b/charts/fluentd/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         {{- end }}
     spec:
       {{- include "fluentd.pod" . | nindent 6 }}
-    {{- with .Values.updateStrategy }}
-    strategy:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -129,6 +129,13 @@ podAnnotations: {}
 ##
 podLabels: {}
 
+## Configure DaemonSet updateStrategy / Deployment strategy
+##
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
 ## Additional environment variables to set for fluentd pods
 env:
 - name: "FLUENTD_CONF"


### PR DESCRIPTION
This change enables the user of the fluentd and fluent-bit Helm charts to configure the rollout strategy for the deployment or daemonset.

Currently, the default rolling update with`maxUnavailable: 1` takes over an hour to do when the `--atomic` flag is used. I'd like to be able to customise my update strategies to whatever I like. This change will enable customisation for users of these helm charts.