### PR TITLE
[fluent-bit] Add  NodePort option to Service

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.16.6
+version: 0.17.0
 appVersion: 1.8.6
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -18,12 +18,18 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   {{- if .Values.extraPorts }}
     {{- range .Values.extraPorts }}
     - name: {{ .name }}
       targetPort: {{ .name }}
       protocol: {{ .protocol }}
       port: {{ .port }}
+      {{- if and (eq $.Values.service.type "NodePort") (.nodePort) }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
     {{- end }}
   {{- end }}
   selector:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -70,6 +70,7 @@ service:
   type: ClusterIP
   port: 2020
   labels: {}
+  # nodePort: 30020
   annotations: {}
 #   prometheus.io/path: "/api/v1/metrics/prometheus"
 #   prometheus.io/port: "2020"
@@ -152,6 +153,7 @@ extraPorts: []
 #     containerPort: 5170
 #     protocol: TCP
 #     name: tcp
+#     nodePort: 30517
 
 extraVolumes: []
 


### PR DESCRIPTION
I made it possible to configure the node port option to fluent-bit service. It is a just simple change related to this.
In my case, it is useful to use the node port when I tried to receive forwarded data from the cluster outside.

Signed-off-by: jonghyun <heiwais25@gmail.com>