### PR TITLE
[fluent-bit] Update initContainers logic

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.18.1
+version: 0.19.0
 appVersion: 1.8.7
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -20,5 +20,7 @@ maintainers:
     email: towmeykaw@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Fluent Bit image to v1.8.7."
+    - kind: added
+      description: "Support setting initContainers to a string value to enable full templating."
+    - kind: removed
+      description: "Don't template initContainers when set to an array."

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -284,7 +284,17 @@ args: []
 
 command: []
 
+# This supports either a structured array or a templatable string
 initContainers: []
+
+# Array mode
+# initContainers:
+#   - name: do-something
+#     image: bitnami/kubectl:1.22
+#     command: ['kubectl', 'version']
+
+# String mode
+# initContainers: |-
 #   - name: do-something
 #     image: bitnami/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}
 #     command: ['kubectl', 'version']


### PR DESCRIPTION
The following changes have been made.

- Change `initContainers` logic
  - Support templating when value is a string
  - No templating when value is an array due to inconsistent behaviour
- Remove whitespace from templates
- Bump chart minor version (major is 0) as breaking change