### PR TITLE
[fluent-bit] Add Relabeling option to ServiceMonitor

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.0
+version: 0.19.1
 appVersion: 1.8.7
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.1
-appVersion: 1.8.9
+version: 0.19.2
+appVersion: 1.8.8
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -21,6 +21,12 @@ spec:
       {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Straightforward change to extend fluentbit ServiceMonitor. This allows to include relabeling configuration as specified here:

https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec