### PR TITLE
[fluentd] Icon URL not working #150

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.0
-appVersion: 1.8.7
+version: 0.19.1
+appVersion: 1.8.8
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -20,7 +20,5 @@ maintainers:
     email: towmeykaw@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Support setting initContainers to a string value to enable full templating."
-    - kind: removed
-      description: "Don't template initContainers when set to an array."
+    - kind: changed
+      description: "Update Fluent Bit image to v1.8.8."

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 # type: application
 version: 0.2.11
 appVersion: v1.12.0
-icon: https://www.fluentd.org/assets/img/miscellany/fluentd-logo_2x.png
+icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/
 sources:
   - https://github.com/fluent/fluentd/


### PR DESCRIPTION
- Looks like icon url no longer returned an image:
![image](https://user-images.githubusercontent.com/11661103/137066811-2462fb1e-a526-458a-b480-cb9dd61e289e.png)

- Fixed with:
![image](https://user-images.githubusercontent.com/11661103/137066839-584119b6-270c-47f4-bb25-c5a76e1781b8.png)
