### PR TITLE
[fluentd] Icon URL not working #150

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: v1.12.0
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 # type: application
 version: 0.2.11
 appVersion: v1.12.0
-icon: https://www.fluentd.org/assets/img/miscellany/fluentd-logo_2x.png
+icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/
 sources:
   - https://github.com/fluent/fluentd/


### PR DESCRIPTION
•	Looks like icon url no longer returned an image:
 
![image](https://user-images.githubusercontent.com/11661103/137075444-1724181a-a65a-4314-9146-a4c40c078fcb.png)

•	Fixed with:
 
![image](https://user-images.githubusercontent.com/11661103/137075458-d3e5cdd7-cfb6-4dda-a134-d4326b92f566.png)


