### PR TITLE
Fixing FLUENTD_CONF to point to /etc/fluent/fluent.conf

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: v1.12.4
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -154,7 +154,7 @@ updateStrategy: {}
 ## Additional environment variables to set for fluentd pods
 env:
 - name: "FLUENTD_CONF"
-  value: "../../etc/fluent/fluent.conf"
+  value: "../../../etc/fluent/fluent.conf"
   # - name: FLUENT_ELASTICSEARCH_HOST
   #   value: "elasticsearch-master"
   # - name: FLUENT_ELASTICSEARCH_PORT


### PR DESCRIPTION
With the current configuration, the entrypoint uses the wrong configuration file:
```
root@fluentd-m7qqg:/home/fluent# cat /proc/1/cmdline
tini--/fluentd/entrypoint.shroot@fluentd-m7qqg:/home/fluent# ps aux | grep fluentd
root           1  0.0  0.0   8308  1936 ?        Ss   07:35   0:00 tini -- /fluentd/entrypoint.sh
root           7  6.3  0.0 140144 63556 ?        Sl   07:35   0:01 ruby /fluentd/vendor/bundle/ruby/2.6.0/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --gemfile /fluentd/Gemfile -r /fluentd/vendor/bundle/ruby/2.6.0/gems/fluent-plugin-elasticsearch-4.3.3/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
root          90 54.0  0.0  87884 39952 ?        R    07:36   0:00 /usr/local/bin/ruby -Eascii-8bit:ascii-8bit /fluentd/vendor/bundle/ruby/2.6.0/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --gemfile /fluentd/Gemfile -r /fluentd/vendor/bundle/ruby/2.6.0/gems/fluent-plugin-elasticsearch-4.3.3/lib/fluent/plugin/elasticsearch_simple_sniffer.rb --under-supervisor
root          92  0.0  0.0  10736  3152 pts/0    S+   07:36   0:00 grep fluentd
```

This fixes it.