### PR TITLE
Support fluentd as statefulset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# ChangeLog
+
+All notable changes to this project are documented in this file.
+
+## [0.3.0] - DATE YYYY/MM/DD
+- Added statefulset suport

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.2.12
+version: 0.3.0
 appVersion: v1.12.0
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -55,6 +55,10 @@ containers:
       {{- print "- name: fluentd-custom-cm-" $key  | nindent 6 }}
         {{- print "mountPath: /etc/fluent/" $key ".d"  | nindent 8 }}
       {{- end }}
+      {{- if .Values.persistence.enabled }}
+      - mountPath: /var/log/fluent
+        name: {{ include "fluentd.fullname" . }}-buffer
+      {{- end }}
 volumes:
   {{- toYaml .Values.volumes | nindent 2 }}
   {{- range $key := .Values.configMapConfigs }}

--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -1,0 +1,52 @@
+{{- if eq .Values.kind "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fluentd.fullname" . }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "fluentd.fullname" . }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fluentd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/fluentd-configurations-cm.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "fluentd.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "fluentd.pod" . | nindent 6 }}
+  {{- if or .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- if or .Values.persistence.enabled }}
+    - metadata:
+        name: {{ include "fluentd.fullname" . }}-buffer
+      spec:
+        accessModes: [{{ .Values.persistence.accessMode }}]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -1,10 +1,10 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# DaemonSet or Deployment
+# DaemonSet, Deployment or StatefulSet
 kind: "DaemonSet"
 
-# # Only applicable for Deployment
+# # Only applicable for Deployment or StatefulSet
 # replicaCount: 1
 
 image:
@@ -181,6 +181,15 @@ volumeMounts:
   mountPath: /etc/fluent
 - name: etcfluentd-config
   mountPath: /etc/fluent/config.d/
+
+## Only available if kind is StatefulSet
+## Fluentd persistence
+##
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 10Gi
 
 ## Fluentd service
 ##


### PR DESCRIPTION
In some scenarios it's useful to deploy fluend as a statefulset to assign a differente pv to each replica.