### PR TITLE
add(fluentd,fluent-bit): added lifecycle object

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.6
+version: 0.19.7
 appVersion: 1.8.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -64,6 +64,8 @@ containers:
         protocol: {{ .protocol }}
       {{- end }}
     {{- end }}
+    lifecycle:
+      {{- toYaml .Values.lifecycle | nindent 6 }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
     readinessProbe:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -64,8 +64,10 @@ containers:
         protocol: {{ .protocol }}
       {{- end }}
     {{- end }}
+  {{- with .Values.lifecycle }}
     lifecycle:
-      {{- toYaml .Values.lifecycle | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
     readinessProbe:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -123,6 +123,11 @@ dashboards:
   labelKey: grafana_dashboard
   annotations: {}
 
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "sleep 20"]
+
 livenessProbe:
   httpGet:
     path: /

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: v1.12.0
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -43,6 +43,8 @@ containers:
       containerPort: {{ $port.containerPort }}
       protocol: {{ $port.protocol }}
     {{- end }}
+    lifecycle:
+      {{- toYaml .Values.lifecycle | nindent 6 }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
     readinessProbe:

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -43,8 +43,10 @@ containers:
       containerPort: {{ $port.containerPort }}
       protocol: {{ $port.protocol }}
     {{- end }}
+    {{- with .Values.lifecycle }}
     lifecycle:
-      {{- toYaml .Values.lifecycle | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
     readinessProbe:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -46,6 +46,13 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Configure the livecycle
+# Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "sleep 20"]
+
 # Configure the livessProbe
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:


### PR DESCRIPTION
This PR adds the possibility to add lifecycle management to the pods. That may be helpful to let the pod running long enough so that it can properly be deregistered from a load balancer.