### PR TITLE
Templates extraFiles values

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.5
+version: 0.20.0
 appVersion: 1.8.9
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Added on serviceMonitor possibility to define jobLabel, metricRelabelings and relabelings"
+      description: "Templates extraFiles values"

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -15,6 +15,6 @@ data:
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
   {{- range $key, $val := .Values.config.extraFiles }}
   {{ $key }}: |
-    {{- $val | nindent 4 }}
+    {{- (tpl $val $) | nindent 4 }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Eli Algranti <eli.algranti@gmail.com>

Templating the value of `extraFiles` allows pulling the content of extra files from e.g. `globals`, and provides feature parity with the rest of the values that make up fluent-bit's configuration.