### PR TITLE
[Fluent-bit] Allow defining namespace for dashboard's ConfigMap

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.8
+version: 0.19.9
 appVersion: 1.8.10
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -5,6 +5,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" $ }}-dashboard-{{ trimSuffix ".json" (base $path) }}
+  {{- with $.Values.dashboards.namespace }}
+  namespace: {{ . }}
+  {{- end }}
   {{- with $.Values.dashboards.annotations }}
   annotations:
     {{- toYaml . | nindent 4 -}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -122,6 +122,7 @@ dashboards:
   enabled: false
   labelKey: grafana_dashboard
   annotations: {}
+  # namespace: ""
 
 lifecycle: {}
   # preStop:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -122,7 +122,7 @@ dashboards:
   enabled: false
   labelKey: grafana_dashboard
   annotations: {}
-  # namespace: ""
+  namespace: ""
 
 lifecycle: {}
   # preStop:


### PR DESCRIPTION
Allows to define a different namespace for dashboard's ConfigMap. 

Signed-off-by: jkosecki <jan.kosecki91@gmail.com>