### PR TITLE
Fix a typo in additionalLabels in fluent-bit chart

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.14
+version: 0.19.15
 appVersion: 1.8.11
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -105,7 +105,7 @@ serviceMonitor:
 prometheusRule:
   enabled: false
 #   namespace: ""
-#   additionnalLabels: {}
+#   additionalLabels: {}
 #   rules:
 #   - alert: NoOutputBytesProcessed
 #     expr: rate(fluentbit_output_proc_bytes_total[5m]) == 0


### PR DESCRIPTION
This PR fixes a typo present in `values.yaml` of the `fluent-bit` chart.
