### PR TITLE
Add support for dynamic values in Env

### DIFF
--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -39,7 +39,7 @@ containers:
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if .Values.env }}
     env:
-      {{- toYaml .Values.env | nindent 6 }}
+      {{- tpl (toYaml .Values.env) . | nindent 6 }}
   {{- end }}
   {{- if .Values.envFrom }}
     envFrom:


### PR DESCRIPTION
This PR add support for allowing injecting dynamic Environment Variables in the DaemonSet. (See #186)

Overview of my `values.yaml` file:
```
mySuperSecret: ""

env:
  - name: MY_SUPER_SECRET
    value: "{{ .Values.mySuperSecret }}"

<...>
```

Export the variable and install the chart with helm
```
export MY_SUPER_SECRET="password123"

helm upgrade fluent-bit --install --debug --values ./values.yaml --set mySuperSecret=${MY_SUPER_SECRET} fluent/fluent-bit
```

❌ : Without this commit/PR, invalid result
```
# kubectl describe pod fluent-bit-95zdc | grep "Environment:" -A1
    Environment:
      MY_SUPER_SECRET:            {{ .Values.mySuperSecret }}
```

✅ : With this commit/PR, valid result
```
# kubectl describe pod fluent-bit-5nsqz | grep "Environment:" -A1
    Environment:
      MY_SUPER_SECRET:            password123
```
