### PR TITLE
Add envWithTpl variable

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Add envWithTpl to support templatable strings in Environment Variables"
+    - kind: added
+      description: "New envWithTpl value to support using templatable strings in environment variables."

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.16
+version: 0.19.17
 appVersion: 1.8.11
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Fluent Bit image to v1.8.11."
+      description: "Add envWithTpl to support templatable strings in Environment Variables"

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -39,12 +39,13 @@ containers:
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if or .Values.env .Values.envWithTpl }}
     env:
-      {{- with .Values.env }}
+    {{- with .Values.env }}
       {{- toYaml . | nindent 6 }}
-      {{- end }}
-      {{- with .Values.envWithTpl }}
-      {{- tpl (toYaml .) $ | nindent 6 }}
-      {{- end }}
+    {{- end }}
+    {{- range $item := .Values.envWithTpl }}
+      - name: {{ $item.name }}
+        value: {{ tpl $item.value $ | quote }}
+    {{- end }}
   {{- end }}
   {{- if .Values.envFrom }}
     envFrom:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -37,9 +37,19 @@ containers:
   {{- end }}
     image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-  {{- if .Values.env }}
+  {{- if or .Values.env .Values.extraEnv }}
     env:
+      {{- if .Values.env }}
       {{- toYaml .Values.env | nindent 6 }}
+      {{- end }}
+      {{- if .Values.extraEnv }}
+      {{- with .Values.extraEnv }}
+      {{- range $key, $val := . }}
+      - name: {{ $key }}
+        value: {{ tpl $val $ | quote }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
   {{- end }}
   {{- if .Values.envFrom }}
     envFrom:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -39,16 +39,11 @@ containers:
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if or .Values.env .Values.envWithTpl }}
     env:
-      {{- if .Values.env }}
-      {{- toYaml .Values.env | nindent 6 }}
+      {{- with .Values.env }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- if .Values.envWithTpl }}
       {{- with .Values.envWithTpl }}
-      {{- range $key, $val := . }}
-      - name: {{ $key }}
-        value: {{ tpl $val $ | quote }}
-      {{- end }}
-      {{- end }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
   {{- end }}
   {{- if .Values.envFrom }}

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -37,13 +37,13 @@ containers:
   {{- end }}
     image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-  {{- if or .Values.env .Values.extraEnv }}
+  {{- if or .Values.env .Values.envWithTpl }}
     env:
       {{- if .Values.env }}
       {{- toYaml .Values.env | nindent 6 }}
       {{- end }}
-      {{- if .Values.extraEnv }}
-      {{- with .Values.extraEnv }}
+      {{- if .Values.envWithTpl }}
+      {{- with .Values.envWithTpl }}
       {{- range $key, $val := . }}
       - name: {{ $key }}
         value: {{ tpl $val $ | quote }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -220,7 +220,9 @@ env: []
 
 envWithTpl: []
 #  - name: FOO_2
-#    value: "bar2"
+#    value: "{{ .Values.foo2 }}"
+#
+# foo2: bar2
 
 envFrom: []
 

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -218,7 +218,7 @@ env: []
 #  - name: FOO
 #    value: "bar"
 
-extraEnv: {}
+envWithTpl: {}
 #  FOO_2: "bar2"
 
 envFrom: []

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -215,6 +215,11 @@ podLabels: {}
 priorityClassName: ""
 
 env: []
+#  - name: FOO
+#    value: "bar"
+
+extraEnv: {}
+#  FOO_2: "bar2"
 
 envFrom: []
 

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -218,8 +218,9 @@ env: []
 #  - name: FOO
 #    value: "bar"
 
-envWithTpl: {}
-#  FOO_2: "bar2"
+envWithTpl: []
+#  - name: FOO_2
+#    value: "bar2"
 
 envFrom: []
 

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -218,6 +218,9 @@ env: []
 #  - name: FOO
 #    value: "bar"
 
+# The envWithTpl array below has the same usage as "env", but is using the tpl function to support templatable string.
+# This can be useful when you want to pass dynamic values to the Chart using the helm argument "--set <variable>=<value>"
+# https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
 envWithTpl: []
 #  - name: FOO_2
 #    value: "{{ .Values.foo2 }}"


### PR DESCRIPTION
Add `envWithTpl` variable that support injecting Environment Variables with supporting values coming from `--set <variable>=<value>`, by using the function `tpl`.

This does not impact the behavior of the Environment Variables defined under `env`, so this is not a breaking change.

Example of values.yaml:
```
mySuperSecret: ""

envWithTpl:
  MY_SUPER_SECRET: "{{ .Values.mySuperSecret }}"
```

Example of helm command:
```
export MY_SUPER_SECRET="password123"

helm upgrade fluent-bit --install --debug --values ./values.yaml --set mySuperSecret=${MY_SUPER_SECRET} fluent/fluent-bit
```

This is a similar fix as https://github.com/fluent/helm-charts/issues/186 that is provided by the PR https://github.com/fluent/helm-charts/pull/202, but uses `range` and does not touch the existing `env` logic.

