### PR TITLE
added minReadySeconds and terminationGracePeriodSeconds for fluentd

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: v1.12.4
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -10,6 +10,9 @@ priorityClassName: {{ .Values.priorityClassName }}
 serviceAccountName: {{ include "fluentd.serviceAccountName" . }}
 securityContext:
   {{- toYaml .Values.podSecurityContext | nindent 2 }}
+{{- with .Values.terminationGracePeriodSeconds }}
+terminationGracePeriodSeconds: {{ . }}
+{{- end }}
 containers:
   - name: {{ .Chart.Name }}
     securityContext:

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
   updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/fluentd/templates/deployment.yaml
+++ b/charts/fluentd/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
   selector:
     matchLabels:
       {{- include "fluentd.selectorLabels" . | nindent 6 }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -16,12 +16,15 @@ spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "fluentd.fullname" . }}
   {{- with .Values.updateStrategy }}
-  strategy:
+  updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "fluentd.selectorLabels" . | nindent 6 }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -53,7 +53,7 @@ lifecycle: {}
   #   exec:
   #     command: ["/bin/sh", "-c", "sleep 20"]
 
-# Configure the livessProbe
+# Configure the livenessProbe
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
@@ -143,6 +143,14 @@ podAnnotations: {}
 ## Labels to be added to fluentd pods
 ##
 podLabels: {}
+
+## How long (in seconds) a pods needs to be stable before progressing the deployment
+##
+minReadySeconds:
+
+## How long (in seconds) a pod may take to exit (useful with lifecycle hooks to ensure lb deregistration is done)
+##
+terminationGracePeriodSeconds:
 
 ## Deployment strategy / DaemonSet updateStrategy
 ##


### PR DESCRIPTION
In this PR i added the ability to better control the deployment of the single fluentd pods.

We are experiencing issues that our pods aren't registered in the clouds load balancer (as they stay in "initial" state longer than needed due to cloud providers restrictions).
To ensure that enough instances are available during a deployment (or simply during scaling activities), i've added two new values:
* terminationGracePeriodSeconds
* minReadySeconds

This will allow the pod to finish all traffic, being deregistered from the load balancer and then exit (due to the pre-stop lifecycle policy added earlier).
New pods will now wait minReadySeconds until letting the deployment controller move on to the next pod.

I chose 30 seconds for terminationGracePeriodSeconds, as i assume this to be the default. However please let me know if this is an incorrect assumption and what would be correct.