### PR TITLE
Update fluent-bit image to 1.8.12

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.17
-appVersion: 1.8.11
+version: 0.19.18
+appVersion: 1.8.12
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "New envWithTpl value to support using templatable strings in environment variables."
+    - kind: changed
+      description: "Update fluent-bit image to 1.8.12."


### PR DESCRIPTION
This PR update fluent-bit image to 1.8.12 and bump the chart version and `artifacthub.io/changes` annotation accordingly.
