### PR TITLE
Update fluent-bit image to 1.8.13

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.19
-appVersion: 1.8.12
+version: 0.19.20
+appVersion: 1.8.13
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update fluent-bit image to 1.8.12."
+      description: "Update fluent-bit image to 1.8.13."


### PR DESCRIPTION
This PR update fluent-bit image to 1.8.13 and bump the chart version and add `artifacthub.io/changes` annotation accordingly.
