### PR TITLE
[fluent-bit] Make `/var/log` volume mount read only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ See `git help commit`:
 * Must pass [DCO check](#sign-off-your-work)
 * Must follow [Charts best practices](https://helm.sh/docs/topics/chart_best_practices/)
 * Must pass CI jobs for linting and installing changed charts with the [chart-testing](https://github.com/helm/chart-testing) tool
-* Any change to a chart requires a version bump following [semver](https://semver.org/) principles. See [Immutability(#immutability) and [Versioning](#versioning) below
+* Any change to a chart requires a version bump following [semver](https://semver.org/) principles. See [Immutability](#immutability) and [Versioning](#versioning) below
 
 Once changes have been merged, the release job will automatically run to package and release changed charts.
 

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.20
+version: 0.19.21
 appVersion: 1.8.13
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -363,6 +363,7 @@ daemonSetVolumes:
 daemonSetVolumeMounts:
   - name: varlog
     mountPath: /var/log
+    readOnly: true
   - name: varlibdockercontainers
     mountPath: /var/lib/docker/containers
     readOnly: true


### PR DESCRIPTION
Currently the `/var/log` mount in the chart is read/write. As best I can tell the Fluentbit pods only need to tail files and have no reason to need write access to anything in `/var/log` (and this seems to hold up in testing using the modified values file in this PR).

It would be a security best practice to change this mount to `readOnly`. For an example of the danger in the current defaults see https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts

Would love to hear feedback on the why if this is needed as a read/write mount, regardless of whether this PR is accepted I'm looking at doing this by default in my deployment and want to validate that I won't see any unexpected consequences as a result.