### PR TITLE
Update fluent-bit image to 1.9.3

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
 version: 0.20.0
-appVersion: 1.9.0
+appVersion: 1.9.2
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update fluent-bit image to 1.9.0."
+      description: "Update fluent-bit image to 1.9.2."

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
 version: 0.20.0
-appVersion: 1.9.2
+appVersion: 1.9.3
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update fluent-bit image to 1.9.2."
+      description: "Update fluent-bit image to 1.9.3."

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.24
-appVersion: 1.8.15
+version: 0.20.0
+appVersion: 1.9.0
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Add ability to manually set clusterIP address."
+    - kind: changed
+      description: "Update fluent-bit image to 1.9.0."


### PR DESCRIPTION
To be honest, I am not sure if anything specific needs to be added/changed in the charts `values.yaml`. I straight forward rely on the assumption of a semver minor increase of flb from 1.8x to 1.9.0 and the fact, that most settings are configured in this helm chart by writing the raw config files so or so.