### PR TITLE
Add ability to optionally set loadBalancerIP and externalTrafficPolicy on Service

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.21
+version: 0.19.22
 appVersion: 1.8.14
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -13,6 +13,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -71,6 +71,8 @@ service:
   port: 2020
   labels: {}
   # nodePort: 30020
+  # loadBalancerIP:
+  # externalTrafficPolicy: Local
   annotations: {}
 #   prometheus.io/path: "/api/v1/metrics/prometheus"
 #   prometheus.io/port: "2020"

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: v1.12.4
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/service.yaml
+++ b/charts/fluentd/templates/service.yaml
@@ -11,6 +11,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - port: 24231
     targetPort: metrics

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -211,6 +211,8 @@ persistence:
 service:
   type: "ClusterIP"
   annotations: {}
+  # loadBalancerIP:
+  # externalTrafficPolicy: Local
   ports: []
   # - name: "forwarder"
   #   protocol: TCP


### PR DESCRIPTION
Setting the loadBalancerIP and externalTrafficPolicy is useful when using the Services as type LoadBalancer.

We need these settings when receiving syslog via a LoadBalancer IP. 