### PR TITLE
fluent bit: update repository path

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.21
+version: 0.19.22
 appVersion: 1.8.14
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -13,7 +13,7 @@ sources:
   - https://github.com/fluent/fluent-bit/
 maintainers:
   - name: edsiper
-    email: eduardo@treasure-data.com
+    email: eduardo@calyptia.com
   - name: naseemkullah
     email: naseem@transit.app
   - name: Towmeykaw

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -7,7 +7,7 @@ kind: DaemonSet
 replicaCount: 1
 
 image:
-  repository: fluent/fluent-bit
+  repository: cr.fluentbit.io/fluent/fluent-bit
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
   tag: ""
   pullPolicy: Always


### PR DESCRIPTION
In newer versions, we are using a new CNAME path to expose the container images:

  cr.fluentbit.io

this is just a CNAME that resolves back to Docker Hub registry but give us more
flexibility and information.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>