### PR TITLE
feat[fluent-bit]: Update image to v1.8.15

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.22
-appVersion: 1.8.14
+version: 0.19.23
+appVersion: 1.8.15
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update fluent-bit image to 1.8.14."
+      description: "Update fluent-bit image to 1.8.15."


### PR DESCRIPTION
This PR updates Fluent Bit to [v1.8.15](https://github.com/fluent/fluent-bit/releases/tag/v1.8.15) and should be merged before the chart moves on to the v1.9.x series.