### PR TITLE
[fluent-bit] Add ability to optionally set `LoadBalancerIP` and `ExternalTrafficPolicy` on Service

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.19.23
+version: 0.19.24
 appVersion: 1.8.15
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -13,6 +13,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -71,6 +71,8 @@ service:
   port: 2020
   labels: {}
   # nodePort: 30020
+  # loadBalancerIP:
+  # externalTrafficPolicy: Local
   annotations: {}
 #   prometheus.io/path: "/api/v1/metrics/prometheus"
 #   prometheus.io/port: "2020"


### PR DESCRIPTION
Setting the loadBalancerIP and externalTrafficPolicy is useful when using the Services as type LoadBalancer.

We need these settings when receiving syslog via a LoadBalancer IP.

Follow up pull request to #221.