### PR TITLE
Add ability to optionally set loadBalancerIP and externalTrafficPolicy on Service

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: v1.12.4
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/service.yaml
+++ b/charts/fluentd/templates/service.yaml
@@ -11,6 +11,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - port: 24231
     targetPort: metrics

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -211,6 +211,8 @@ persistence:
 service:
   type: "ClusterIP"
   annotations: {}
+  # loadBalancerIP:
+  # externalTrafficPolicy: Local
   ports: []
   # - name: "forwarder"
   #   protocol: TCP


### PR DESCRIPTION
Setting the loadBalancerIP and externalTrafficPolicy is useful when using the Services as type LoadBalancer.

We need these settings when receiving syslog via a LoadBalancer IP.

Follow up pull request to #221.