### PR TITLE
Add initial Openshift SCC support for Fluent-Bit

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.0
+version: 0.20.1
 appVersion: 1.9.3
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update fluent-bit image to 1.9.3."
+    - kind: added
+      description: "Add initial Openshift SCC support"

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -29,4 +29,14 @@ rules:
     verbs:
       - use
   {{- end }}
+  {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - {{ include "fluent-bit.fullname" . }}
+    verbs:
+      - use
+  {{- end }}
 {{- end -}}

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+{{- if .Values.openShift.securityContextConstraints.annotations }}
+  annotations:
+    {{- toYaml .Values.openShift.securityContextConstraints.annotations | nindent 4 }}
+{{- end }}
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+defaultAllowPrivilegeEscalation: false
+# forbid host namespaces
+allowHostNetwork: false
+allowHostIPC: false
+allowHostPorts: false
+allowHostPID: false
+allowedCapabilities: []
+forbiddenSysctls:
+- "*"
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - secret
+{{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -35,6 +35,14 @@ podSecurityPolicy:
   create: false
   annotations: {}
 
+openShift:
+  # Sets Openshift support
+  enabled: false
+  # Creates SCC for Fluent-bit when Openshift support is enabled
+  securityContextConstraints:
+    create: true
+    annotations: {}
+
 podSecurityContext: {}
 #   fsGroup: 2000
 


### PR DESCRIPTION
Because of Openshift uses security API different from Kubernetes,
there are additional object called SecurityContextConstraints required
for access logs on Openshift nodes. I add this object, in state as it's
uses in Openshift's cluster-logging-operator.

Signed-off-by: Kirill Thirteen <thethir13en@gmail.com>