### PR TITLE
Update fluent-bit image to 1.9.4

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.1
-appVersion: 1.9.3
+version: 0.20.2
+appVersion: 1.9.4
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Add initial Openshift SCC support"
+    - kind: changed
+      description: "Update fluent-bit image to 1.9.4."


### PR DESCRIPTION
This PR update the Fluent Bit image to latest stable version 1.9.4 and bump the chart version accordingly and add a change annotation about it.
