### PR TITLE
feat(fluent-bit): add support for templated podAnnotations

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.2
+version: 0.20.3
 appVersion: 1.9.4
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml . ) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "fluent-bit.selectorLabels" . | nindent 8 }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml . ) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "fluent-bit.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
This PR adds a small but important support for a feature. 

Imagine you have a k8s secrets file, e.g. for elasticsearch username/password, and you must maintain an additional file in the template folder for it. 
When a secret changes, the fluentbit config does not "rotate" - instead it stays the same and "does not see" that there is a new username/password and the pod should restart. 

Unless of course, you do something like this:
```
podAnnotations: 
  checksum/secrets: '{{ include (print $.Template.BasePath "/MY_secrets.yaml") . | sha256sum }}'
```

which will append annotation to the pod and it will cause fluentbit to restart, whenever secret hash that is being generated is changed. This is a perfectly normal approach and is already being used in the chart. 

And here it comes: Currently, the only way, how i can add above `checksum/secret` is by inserting it directly into `deployment/deamonset.yaml` which is not so nice. It would be much better to make `podAnnotations` flexible enough so that it accept both templated and non-templated values, wouldn't it? This PR does that - and the benefit is that behavior doesn't change at all. No breaking changes. 

This has been tested with following:

MY_secrets.yaml
```
apiVersion: v1
kind: Secret
metadata:
  name: {{ include "fluent-bit.fullname" . | quote }}
  labels:
    {{- include "fluent-bit.labels" . | nindent 4 }}
  {{- with .Values.service.annotations }}
  annotations:
    {{- toYaml . | nindent 4 }}
  {{- end }}
type: Opaque
stringData:
  tesT: "test"
```


values.yaml (see above)
```
podAnnotations: 
  checksum/secrets: '{{ include (print $.Template.BasePath "/MY_secrets.yaml") . | sha256sum }}'
```

It would be nice to have it accepted. :) 