### PR TITLE
[fluentd] Set fileconfigs as a suggestion

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.9
+version: 0.3.10
 appVersion: v1.14.6
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -298,92 +298,92 @@ configMapConfigs:
 
 ## Fluentd configurations:
 ##
-fileConfigs:
-  01_sources.conf: |-
-    ## logs from podman
-    <source>
-      @type tail
-      @id in_tail_container_logs
-      @label @KUBERNETES
-      path /var/log/containers/*.log
-      pos_file /var/log/fluentd-containers.log.pos
-      tag kubernetes.*
-      read_from_head true
-      <parse>
-        @type multi_format
-        <pattern>
-          format json
-          time_key time
-          time_type string
-          time_format "%Y-%m-%dT%H:%M:%S.%NZ"
-          keep_time_key false
-        </pattern>
-        <pattern>
-          format regexp
-          expression /^(?<time>.+) (?<stream>stdout|stderr)( (.))? (?<log>.*)$/
-          time_format '%Y-%m-%dT%H:%M:%S.%NZ'
-          keep_time_key false
-        </pattern>
-      </parse>
-      emit_unmatched_lines true
-    </source>
-
-  02_filters.conf: |-
-    <label @KUBERNETES>
-      <match kubernetes.var.log.containers.fluentd**>
-        @type relabel
-        @label @FLUENT_LOG
-      </match>
-
-      # <match kubernetes.var.log.containers.**_kube-system_**>
-      #   @type null
-      #   @id ignore_kube_system_logs
-      # </match>
-
-      <filter kubernetes.**>
-        @type kubernetes_metadata
-        @id filter_kube_metadata
-        skip_labels false
-        skip_container_metadata false
-        skip_namespace_metadata true
-        skip_master_url true
-      </filter>
-
-      <match **>
-        @type relabel
-        @label @DISPATCH
-      </match>
-    </label>
-
-  03_dispatch.conf: |-
-    <label @DISPATCH>
-      <filter **>
-        @type prometheus
-        <metric>
-          name fluentd_input_status_num_records_total
-          type counter
-          desc The total number of incoming records
-          <labels>
-            tag ${tag}
-            hostname ${hostname}
-          </labels>
-        </metric>
-      </filter>
-
-      <match **>
-        @type relabel
-        @label @OUTPUT
-      </match>
-    </label>
-
-  04_outputs.conf: |-
-    <label @OUTPUT>
-      <match **>
-        @type elasticsearch
-        host "elasticsearch-master"
-        port 9200
-        path ""
-        user elastic
-        password changeme
-      </match>
-    </label>
+fileConfigs: {}
+#  01_sources.conf: |-
+#    ## logs from podman
+#    <source>
+#      @type tail
+#      @id in_tail_container_logs
+#      @label @KUBERNETES
+#      path /var/log/containers/*.log
+#      pos_file /var/log/fluentd-containers.log.pos
+#      tag kubernetes.*
+#      read_from_head true
+#      <parse>
+#        @type multi_format
+#        <pattern>
+#          format json
+#          time_key time
+#          time_type string
+#          time_format "%Y-%m-%dT%H:%M:%S.%NZ"
+#          keep_time_key false
+#        </pattern>
+#        <pattern>
+#          format regexp
+#          expression /^(?<time>.+) (?<stream>stdout|stderr)( (.))? (?<log>.*)$/
+#          time_format '%Y-%m-%dT%H:%M:%S.%NZ'
+#          keep_time_key false
+#        </pattern>
+#      </parse>
+#      emit_unmatched_lines true
+#    </source>
+#
+#  02_filters.conf: |-
+#    <label @KUBERNETES>
+#      <match kubernetes.var.log.containers.fluentd**>
+#        @type relabel
+#        @label @FLUENT_LOG
+#      </match>
+#
+#      # <match kubernetes.var.log.containers.**_kube-system_**>
+#      #   @type null
+#      #   @id ignore_kube_system_logs
+#      # </match>
+#
+#      <filter kubernetes.**>
+#        @type kubernetes_metadata
+#        @id filter_kube_metadata
+#        skip_labels false
+#        skip_container_metadata false
+#        skip_namespace_metadata true
+#        skip_master_url true
+#      </filter>
+#
+#      <match **>
+#        @type relabel
+#        @label @DISPATCH
+#      </match>
+#    </label>
+#
+#  03_dispatch.conf: |-
+#    <label @DISPATCH>
+#      <filter **>
+#        @type prometheus
+#        <metric>
+#          name fluentd_input_status_num_records_total
+#          type counter
+#          desc The total number of incoming records
+#          <labels>
+#            tag ${tag}
+#            hostname ${hostname}
+#          </labels>
+#        </metric>
+#      </filter>
+#
+#      <match **>
+#        @type relabel
+#        @label @OUTPUT
+#      </match>
+#    </label>
+#
+#  04_outputs.conf: |-
+#    <label @OUTPUT>
+#      <match **>
+#        @type elasticsearch
+#        host "elasticsearch-master"
+#        port 9200
+#        path ""
+#        user elastic
+#        password changeme
+#      </match>
+#    </label>


### PR DESCRIPTION
If users would not want to use the default fileConfigs configuration they
would require to replace all file entries with empty string. This way,
the configuration is presented as a suggestion and no need to overwrite
the default configurations if we dont want to use them

Closes: https://github.com/fluent/helm-charts/issues/169
Signed-off-by: Diogo Guerra <diogo.filipe.tomas.guerra@cern.ch>