### PR TITLE
feat[fluent-bit]: Add resourcequota

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.5
+version: 0.20.6
 appVersion: 1.9.7
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated fluent-bit image to 1.9.7."
+      description: "Add option to deploy a ResourceQuota."

--- a/charts/fluent-bit/templates/resourcequota.yaml
+++ b/charts/fluent-bit/templates/resourcequota.yaml
@@ -1,13 +1,15 @@
-{{- if .Values.resourceQuota }}
+{{- if .Values.resourceQuota.enabled }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
-  name: {{ include "fluent-bit.fullname" . }}-critical-pods
+  name: {{ include "fluent-bit.fullname" . }}
 spec:
+  {{- with .Values.resourceQuota.hard }}
   hard:
-    pods: {{ .Values.podCountLimit }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   scopeSelector:
     matchExpressions:
       - operator: In

--- a/charts/fluent-bit/templates/resourcequota.yaml
+++ b/charts/fluent-bit/templates/resourcequota.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.resourceQuota }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+  name: {{ include "fluent-bit.fullname" . }}-critical-pods
+spec:
+  hard:
+    pods: {{ .Values.podCountLimit }}
+  scopeSelector:
+    matchExpressions:
+      - operator: In
+        scopeName: PriorityClass
+        values:
+          - {{ .Values.priorityClassName }}
+{{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -221,9 +221,10 @@ podAnnotations: {}
 
 podLabels: {}
 
-resourceQuota: false
-
-podCountLimit: "1G"
+resourceQuota:
+  enabled: false
+  hard:
+    pods: "1G"
 
 priorityClassName: ""
 

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -221,6 +221,10 @@ podAnnotations: {}
 
 podLabels: {}
 
+resourceQuota: false
+
+podCountLimit: "1G"
+
 priorityClassName: ""
 
 env: []


### PR DESCRIPTION
GKE limits priority class consumption by default. This commit adds the
option to add a ResourceQuota to ensure that pods can be scheduled when
the priority class is set.

Installing fluent-bit with `priorityClass: system-critical-nodes` on a GKE cluster resulted in these errors:
```
Events:
  Type     Reason        Age                  From                  Message
  ----     ------        ----                 ----                  -------
  Warning  FailedCreate  24s (x16 over 3m8s)  daemonset-controller  Error creating: insufficient quota to match these scopes: [{PriorityClass In [system-node-critical system-cluster-critical]}]
```

This PR adds the option to create a `ResourceQuota` if priority classes are being used.

Other relevant links:
https://github.com/open-policy-agent/gatekeeper/issues/1120
https://cloud.google.com/kubernetes-engine/quotas