### PR TITLE
feat[fluent-bit]: Updated image to v1.9.7

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.4
-appVersion: 1.9.6
+version: 0.20.5
+appVersion: 1.9.7
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update fluent-bit image to 1.9.6."
+      description: "Updated fluent-bit image to 1.9.7."


### PR DESCRIPTION
This PR updates the Fluent Bit image to [v1.9.7](https://github.com/fluent/fluent-bit/releases/tag/v1.9.7) ([release notes](https://fluentbit.io/announcements/v1.9.7/)).