### PR TITLE
Add upstream values option to configmap

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated fluent-bit image to 1.9.7."
+      description: "Additional upstream config option added"

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.5
+version: 0.20.6
 appVersion: 1.9.7
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -13,6 +13,10 @@ data:
     {{- (tpl .Values.config.inputs $)  | nindent 4 }}
     {{- (tpl .Values.config.filters $)  | nindent 4 }}
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
+  {{- range $key, $val := .Values.config.upstream }}
+  {{ $key }}: |
+    {{- (tpl $val $) | nindent 4 }}
+  {{- end }}
   {{- range $key, $val := .Values.config.extraFiles }}
   {{ $key }}: |
     {{- (tpl $val $) | nindent 4 }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -330,6 +330,17 @@ config:
         Logstash_Prefix node
         Retry_Limit False
 
+  ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers
+  upstream: {}
+#      upstream.conf: |
+#        [UPSTREAM]
+#            upstream1
+#
+#        [NODE]
+#            name       node-1
+#            host       127.0.0.1
+#            port       43000
+
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]


### PR DESCRIPTION
This will add [upstream server](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers) config option to the configmap. This includes multiple or none upstream configuration files to be generated.

Related PR: https://github.com/fluent/helm-charts/pull/69

Signed-off-by: dominykasn <dominykas.norkus@hostinger.com>