### PR TITLE
Update fluent-bit image to 1.9.8

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.6
-appVersion: 1.9.7
+version: 0.20.7
+appVersion: 1.9.8
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Additional upstream config option added"
+      description: "Update fluent-bit image to 1.9.8"


### PR DESCRIPTION
This PR updates Fluent Bit image to 1.9.8, document that in the artifacthub.io/changes annotation as usual and bump the chart version by one.
