### PR TITLE
[fluentd] Add option to configure podManagementPolicy for StatefulSet

### DIFF
--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "fluentd.fullname" . }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -30,6 +30,10 @@ podSecurityPolicy:
   enabled: true
   annotations: {}
 
+# Configure podManagementPolicy
+# Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#deployment-and-scaling-guarantees
+podManagementPolicy: "OrderedReady"
+
 ## Security Context policies for controller pods
 ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
 ## notes on enabling and using sysctls


### PR DESCRIPTION
Signed-off-by: Aliaksandr Shulyak <alekzander.shulyak@protonmail.com>


Add option to configure podManagementPolicy for StatefulSet.
For example useful in case you are configuring affinity for pods as well.