### PR TITLE
[fluent-bit] feat: Add ability to specify more rules inside NetworkPolicy

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.21.3
+version: 0.22.0
 appVersion: 2.0.5
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,5 +22,9 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Fluent Bit configuration files URL"
+    - kind: added
+      description: "Ability to include provided extraPorts inside NetworkPolicy"
+    - kind: added
+      description: "Ability to provide custom egress rules inside NetworkPolicy"
+    - kind: added
+      description: "Ability to provide custom ingress rules inside NetworkPolicy"

--- a/charts/fluent-bit/templates/networkpolicy.yaml
+++ b/charts/fluent-bit/templates/networkpolicy.yaml
@@ -7,16 +7,30 @@ metadata:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 spec:
   policyTypes:
+    {{- if .Values.networkPolicy.egress.customRules }}
+    - "Egress"
+    {{- end }}
     - "Ingress"
   podSelector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+  {{- with .Values.networkPolicy.egress.customRules }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ingress:
-    {{- with .Values.networkPolicy.ingress }}
     - from:
-        {{- with .from }}{{- . | toYaml | nindent 8 }}{{- else }} []{{- end }}
+        {{- toYaml .Values.networkPolicy.ingress.from | nindent 8 }}
       ports:
         - protocol: "TCP"
-          port: {{ $.Values.service.port }}
+          port: {{ .Values.service.port }}
+        {{- if .Values.networkPolicy.ingress.includeExtraPorts }}
+          {{- range .Values.extraPorts }}
+        - protocol: {{ .protocol | quote }}
+          port: {{ .port }}
+          {{- end }}
+        {{- end}}
+    {{- with .Values.networkPolicy.ingress.customRules }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -279,8 +279,30 @@ existingConfigMap: ""
 
 networkPolicy:
   enabled: false
-#   ingress:
-#     from: []
+  egress:
+    customRules: []
+    # - to:
+    #     - ipBlock:
+    #         cidr: 10.0.0.0/24
+    #   ports:
+    #     - protocol: TCP
+    #       port: 8443
+  ingress:
+    customRules: []
+    # - from:
+    #     - ipBlock:
+    #         cidr: 172.17.0.0/16
+    #         except:
+    #           - 172.17.1.0/24
+    #   ports:
+    #     - protocol: TCP
+    #       port: 2020
+    from: []
+    # - ipBlock:
+    #     cidr: 172.17.0.0/16
+    #     except:
+    #       - 172.17.1.0/24
+    includeExtraPorts: false
 
 luaScripts: {}
 


### PR DESCRIPTION
Implemented 3 features around the existing NetworkPolicy:
- Ability to include provided extraPorts inside NetworkPolicy (`networkPolicy.ingress.includeExtraPorts`)
- Ability to provide custom egress rules inside NetworkPolicy (`networkPolicy.egress.customRules`)
- Ability to provide custom ingress rules inside NetworkPolicy (`networkPolicy.ingress.customRules`)

/cc: @AlexisMtr as you implemented basic NetworkPolicy support in https://github.com/fluent/helm-charts/pull/65