### PR TITLE
[fluentd] add network policy

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.9
+version: 0.4.0
 appVersion: v1.14.6
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/networkpolicy.yaml
+++ b/charts/fluentd/templates/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "fluentd.fullname" . }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "fluentd.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      - port: 24231
+        protocol: TCP
+      {{- if .Values.service.ports }}
+      {{- range $port := .Values.service.ports }}
+      - port: {{ $port.containerPort }}
+        protocol: {{ $port.protocol }}
+      {{- end }}
+      {{- end }}
+  {{- with .Values.networkPolicy }}
+  egress:
+    {{- toYaml .egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -159,6 +159,11 @@ updateStrategy: {}
 #   rollingUpdate:
 #     maxUnavailable: 1
 
+# NetworkPolicy, egress rules can be configured if needed
+networkPolicy:
+  enabled: false
+  egress: []
+
 ## Additional environment variables to set for fluentd pods
 env:
 - name: "FLUENTD_CONF"


### PR DESCRIPTION
This PR adds an optional `NetworkPolicy` resource. It automatically opens the metrics & services ports + let you configure egress ports if needed.
