### PR TITLE
[fluent-bit] Add volumeMounts for upstream configuration files

### DIFF
--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -84,6 +84,11 @@ containers:
   {{- end }}
     volumeMounts:
       {{- toYaml .Values.volumeMounts | nindent 6 }}
+    {{- range $key, $val := .Values.config.upstream }}
+      - name: config
+        mountPath: /fluent-bit/etc/{{ $key }}
+        subPath: {{ $key }}
+    {{- end }}
     {{- range $key, $val := .Values.config.extraFiles }}
       - name: config
         mountPath: /fluent-bit/etc/{{ $key }}


### PR DESCRIPTION
This PR add volumeMounts for fluent-bit upstream configuration files, which solves files under `Values.config.upstream` are not properly mounted.

Closes: #270 