### PR TITLE
[fluent-bit] Mark `config.upstream` as deprecated

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.9
+version: 0.20.10
 appVersion: 1.9.9
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit image to v1.9.9."
+      description: "Mark config.upstream as deprecated"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -31,7 +31,7 @@ First, you should add your Lua scripts to `luaScripts` in values.yaml, for examp
 
 ```yaml
 luaScripts:
- filter_example.lua: |
+  filter_example.lua: |
     function filter_name(tag, timestamp, record)
         -- put your lua code here.
     end

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -333,15 +333,8 @@ config:
         Retry_Limit False
 
   ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers
+  ## This configuration is deprecated, please use `extraFiles` instead.
   upstream: {}
-#      upstream.conf: |
-#        [UPSTREAM]
-#            upstream1
-#
-#        [NODE]
-#            name       node-1
-#            host       127.0.0.1
-#            port       43000
 
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
@@ -355,6 +348,14 @@ config:
   # This allows adding more files with arbitary filenames to /fluent-bit/etc by providing key/value pairs.
   # The key becomes the filename, the value becomes the file content.
   extraFiles: {}
+#     upstream.conf: |
+#       [UPSTREAM]
+#           upstream1
+#
+#       [NODE]
+#           name       node-1
+#           host       127.0.0.1
+#           port       43000
 #     example.conf: |
 #       [OUTPUT]
 #           Name example


### PR DESCRIPTION
This PR mark `config.upstream` as deprecated corresponding to the conclusion in #271.

Closes: #270 