### PR TITLE
Add terminationGracePeriodSeconds and minReadySeconds for fluent-bit

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Mark config.upstream as deprecated"
+    - kind: added
+      description: "Support for terminationGracePeriodSeconds and minReadySeconds added"

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.10
+version: 0.20.11
 appVersion: 1.9.9
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -11,6 +11,9 @@ priorityClassName: {{ .Values.priorityClassName }}
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.terminationGracePeriodSeconds }}
+terminationGracePeriodSeconds: {{ . }}
+{{- end }}
 hostNetwork: {{ .Values.hostNetwork }}
 dnsPolicy: {{ .Values.dnsPolicy }}
 {{- with .Values.dnsConfig }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
   updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -223,6 +223,14 @@ podAnnotations: {}
 
 podLabels: {}
 
+## How long (in seconds) a pods needs to be stable before progressing the deployment
+##
+minReadySeconds:
+
+## How long (in seconds) a pod may take to exit (useful with lifecycle hooks to ensure lb deregistration is done)
+##
+terminationGracePeriodSeconds:
+
 priorityClassName: ""
 
 env: []


### PR DESCRIPTION
In pull request I've add ability to controll time which kubernetes shoud wait with pod termination after deregistering target in load balancer. 
Our use case is decrease logs lossess arisen during pods rotation.


To be compilant with fluent-d configuration I also add minReadySeconds support (https://github.com/fluent/helm-charts/pull/204)

Signed-off-by: Jacek <jacek.socha@gmail.com>