### PR TITLE
fix(fluent-bit): bump chart

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.20.10
+version: 0.20.11
 appVersion: 1.9.9
 icon: https://fluentbit.io/assets/img/logo1-default.png
 home: https://fluentbit.io/


### PR DESCRIPTION
Thanks for merging https://github.com/fluent/helm-charts/pull/265
Although the release build failed (https://github.com/fluent/helm-charts/actions/runs/3430925908/jobs/5718462000) because meanwhile the chart was already bumped to 0.20.10 in master.This pr bumps the chart again.

prs should be enforced to rebase/merge master before merge to avoid this I guess.