### PR TITLE
[fluent-bit] Update Configuration File URL

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.21.2
+version: 0.21.3
 appVersion: 2.0.5
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Fix broken icon URL"
+      description: "Update Fluent Bit configuration files URL"

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -284,7 +284,7 @@ networkPolicy:
 
 luaScripts: {}
 
-## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
+## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file
 config:
   service: |
     [SERVICE]


### PR DESCRIPTION
Since Fluent Bit 1.9 the configuration file URL was moved under the classic mode section to distinguish it with the YAML configuration.

This PR updates it to avoid the broken URL and continue to point out to the classic configuration format preferred by the Helm chart.
