### PR TITLE
[fluent-bit] Update `fluent-bit` image to 2.0.6

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.21.3
-appVersion: 2.0.5
+version: 0.21.4
+appVersion: 2.0.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Fluent Bit configuration files URL"
+      description: "Update fluent-bit image to 2.0.6"


### PR DESCRIPTION
This PR updates to latest fluent-bit 2.0.6.
