### PR TITLE
[fluent-bit] Add support for service.loadBalancerSourceRanges and service.loadBalancerClass

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.21.4
+version: 0.21.5
 appVersion: 2.0.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update fluent-bit image to 2.0.6"
+    - kind: added
+      description: "Add support for service.loadBalancerSourceRanges and service.loadBalancerClass"

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -16,6 +16,15 @@ spec:
   {{- if and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if (eq .Values.service.type "LoadBalancer")}}
+  {{- with .Values.service.loadBalancerClass}}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- with .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -78,6 +78,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 2020
+  loadBalancerClass:
+  loadBalancerSourceRanges: []
   labels: {}
   # nodePort: 30020
   # clusterIP: 172.16.10.1


### PR DESCRIPTION
This PR exposes support for setting fields relevant to `type: LoadBalancer` services. https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec