### PR TITLE
[fluentd] improve configmap names

### DIFF
--- a/charts/fluentd/templates/files.conf/prometheus.yaml
+++ b/charts/fluentd/templates/files.conf/prometheus.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
-  name: fluentd-prometheus-conf
+  name: {{ include "fluentd.fullname" . }}-fluentd-prometheus-conf
 data:
   prometheus.conf: |-
     <source>

--- a/charts/fluentd/templates/files.conf/systemd.yaml
+++ b/charts/fluentd/templates/files.conf/systemd.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
-  name: fluentd-systemd-conf
+  name: {{ include "fluentd.fullname" . }}-fluentd-systemd-conf
 data:
   systemd.conf: |-
     <source>

--- a/charts/fluentd/templates/fluentd-configurations-cm.yaml
+++ b/charts/fluentd/templates/fluentd-configurations-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluentd-config
+  name: {{ include "fluentd.fullname" . }}-fluentd-config
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
 data:
@@ -15,7 +15,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluentd-main
+  name: {{ include "fluentd.fullname" . }}-fluentd-main
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
 data:


### PR DESCRIPTION
#289

Improve fluentd configmap names so that you can deploy fluentd helm chart multiple times in one namespace.