### PR TITLE
fix: disable psp for Kubernetes version >= 1.25

### DIFF
--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- if .Values.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -39,4 +40,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -32,6 +32,11 @@ rbac:
   create: true
   nodeAccess: false
 
+# Configure podsecuritypolicy
+# Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+# from Kubernetes 1.25, PSP is deprecated
+# See: https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes
+# We automatically disable PSP if Kubernetes version is 1.25 or higher
 podSecurityPolicy:
   create: false
   annotations: {}

--- a/charts/fluentd/templates/podsecuritypolicy.yaml
+++ b/charts/fluentd/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -25,7 +26,7 @@ spec:
     - 'persistentVolumeClaim'
     {{- end }}
   runAsUser:
-    rule: 'RunAsAny'    
+    rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
@@ -39,4 +40,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -26,6 +26,9 @@ rbac:
 
 # Configure podsecuritypolicy
 # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+# from Kubernetes 1.25, PSP is deprecated
+# See: https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes
+# We automatically disable PSP if Kubernetes version is 1.25 or higher
 podSecurityPolicy:
   enabled: true
   annotations: {}


### PR DESCRIPTION
Starting with Kubernetes version 1.25, the developers have decided to completely remove the **PSP** API. Since this causes Helm deployments to fail, the PSP deployment must be explicitly disabled for newer Kubernetes versions. This PR adds a *capability* version check to the PSP configuration.
