### PR TITLE
fix: disable fluent-bit psp config

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.21.5
+version: 0.21.6
 appVersion: 2.0.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Add support for service.loadBalancerSourceRanges and service.loadBalancerClass"
+    - kind: fixed
+      description: "Prevent PodSecurityPolicy from being created when Kubernetes version is 1.25 or higher"

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -19,7 +19,7 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.podSecurityPolicy.create }}
+  {{- if and .Values.podSecurityPolicy.create semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion }}
   - apiGroups:
       - policy
     resources:

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -19,7 +19,7 @@ rules:
       - get
       - list
       - watch
-  {{- if and .Values.podSecurityPolicy.create semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if and .Values.podSecurityPolicy.create (semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion) }}
   - apiGroups:
       - policy
     resources:

--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- if .Values.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -39,4 +40,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -1,5 +1,4 @@
-{{- if semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- if .Values.podSecurityPolicy.create }}
+{{- if and .Values.podSecurityPolicy.create semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -40,5 +39,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}

--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podSecurityPolicy.create semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.podSecurityPolicy.create (semverCompare "<=1.25-0" .Capabilities.KubeVersion.GitVersion) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -32,6 +32,11 @@ rbac:
   create: true
   nodeAccess: false
 
+# Configure podsecuritypolicy
+# Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+# from Kubernetes 1.25, PSP is deprecated
+# See: https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes
+# We automatically disable PSP if Kubernetes version is 1.25 or higher
 podSecurityPolicy:
   create: false
   annotations: {}


### PR DESCRIPTION
Starting with Kubernetes version 1.25, the developers have decided to completely remove the PSP API. Since this causes Helm deployments to fail, the PSP deployment must be explicitly disabled for newer Kubernetes versions. This PR adds a capability version check to the PSP configuration.