### PR TITLE
feat(fluent-bit): use fluent-bit service account in testFramework

### DIFF
--- a/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
   containers:
     - name: wget
       image: "{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"


### PR DESCRIPTION
It should resolve the following error:

```
Error from server (Forbidden): error when creating "values.yaml": pods "...-fluent-bit-test-connection" is forbidden: error looking up service account .../default: serviceaccount "default" not found
```