### PR TITLE
[fluent-bit] Add shareProcessNamespace option

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.21.7
+version: 0.21.8
 appVersion: 2.0.8
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
 version: 0.21.8
-appVersion: 2.0.8
+appVersion: 2.0.9
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update fluent-bit image to 2.0.8"
+    - kind: add
+      description: "Add shareProcessNamespace option"

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -1,7 +1,7 @@
 {{- define "fluent-bit.pod" -}}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 {{- with .Values.imagePullSecrets }}
-{{ if  .Values.shareProcessNamespace }}
+{{ if .Values.shareProcessNamespace }}
 shareProcessNamespace: true
 {{ end }}
 imagePullSecrets:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -1,6 +1,9 @@
 {{- define "fluent-bit.pod" -}}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 {{- with .Values.imagePullSecrets }}
+{{ if  .Values.shareProcessNamespace }}
+shareProcessNamespace: true
+{{ end }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -256,6 +256,10 @@ envWithTpl: []
 
 envFrom: []
 
+# shareProcessNamespace enables process namespace sharing between fluent-bit and the extraContainers
+# This is useful if fluent-bit must be signaled, e.g. to send a SIGHUP for a configuration reload
+shareProcessNamespace: false
+
 extraContainers: []
 #   - name: do-something
 #     image: busybox


### PR DESCRIPTION
@stevehipwell apologies for accidentally closing #298.
>@drehelis before this PR moves any further please could you split it up so a PR is only for a single chart. Could you also explain why you need the change and what alternatives you've tried/considered?

I need to be able to add configuration to fluent-bit and signal the service to reload itself. As currently fluent-bit [does not support dynamically re-reading the configuration](https://github.com/fluent/fluent-bit/issues/365).

As I'm required to carry the operation from inside the pod, using extra container is an ideal solution for me, therefore `shareProcessNamespace` becomes handy. I'm able to signal fluent-bit gracefully to shutdown and restart to pickup the new config.

I've tried the `fluent-bit operator` but that's just overkill in my case.
Executing `rollout restart` is not an option due to permissions.