### PR TITLE
[fluentd] Allow disable defaults

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.3.9
+version: 0.3.10
 appVersion: v1.14.6
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -62,6 +62,14 @@ containers:
       {{- toYaml .Values.resources | nindent 8 }}
     volumeMounts:
       {{- toYaml .Values.volumeMounts | nindent 6 }}
+      {{- if .Values.defaultConfigs.prometheusConf.enabled }}
+      - name: fluentd-custom-cm-fluentd-prometheus-conf
+        mountPath: /etc/fluent/fluentd-prometheus-conf.d
+      {{- end }}
+      {{- if .Values.defaultConfigs.systemdConf.enabled }}
+      - name: fluentd-custom-cm-fluentd-systemd-conf
+        mountPath: /etc/fluent/fluentd-systemd-conf.d
+      {{- end }}
       {{- range $key := .Values.configMapConfigs }}
       {{- print "- name: fluentd-custom-cm-" $key  | nindent 6 }}
         {{- print "mountPath: /etc/fluent/" $key ".d"  | nindent 8 }}
@@ -72,6 +80,18 @@ containers:
       {{- end }}
 volumes:
   {{- toYaml .Values.volumes | nindent 2 }}
+  {{- if .Values.defaultConfigs.prometheusConf.enabled }}
+  - name: fluentd-custom-cm-fluentd-prometheus-conf
+    configMap:
+      name: fluentd-prometheus-conf
+      defaultMode: 0777
+  {{- end }}
+  {{- if .Values.defaultConfigs.systemdConf.enabled }}
+  - name: fluentd-custom-cm-fluentd-systemd-conf
+    configMap:
+      name: fluentd-systemd-conf
+      defaultMode: 0777
+  {{- end }}
   {{- range $key := .Values.configMapConfigs }}
   {{- print "- name: fluentd-custom-cm-" $key  | nindent 2 }}
     configMap:

--- a/charts/fluentd/templates/files.conf/prometheus.yaml
+++ b/charts/fluentd/templates/files.conf/prometheus.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.defaultConfigs.prometheusConf.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,3 +24,4 @@ data:
       @type prometheus_output_monitor
       @id in_prometheus_output_monitor
     </source>
+{{- end }}

--- a/charts/fluentd/templates/files.conf/systemd.yaml
+++ b/charts/fluentd/templates/files.conf/systemd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.defaultConfigs.systemdConf.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -81,3 +82,4 @@ data:
         @label @DISPATCH
       </match>
     </label>
+{{- end }}

--- a/charts/fluentd/templates/fluentd-configurations-cm.yaml
+++ b/charts/fluentd/templates/fluentd-configurations-cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.fileConfigs }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,9 +6,9 @@ metadata:
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
 data:
-{{- range $key, $value := .Values.fileConfigs }}
-  {{$key }}: |-
-    {{- $value | nindent 4 }}
+{{- range .Values.fileConfigs }}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
 {{- end }}
 
 ---
@@ -29,6 +30,12 @@ data:
     </label>
 
     @include config.d/*.conf
+    {{- if .Values.defaultConfigs.prometheusConf.enabled }}
+    {{- print "@include fluentd-prometheus-conf.d/*"  | nindent 4 }}
+    {{- end}}
+    {{- if .Values.defaultConfigs.systemdConf.enabled }}
+    {{- print "@include fluentd-systemd-conf.d/*"  | nindent 4 }}
+    {{- end}}
     {{- range $key := .Values.configMapConfigs }}
     {{- print "@include " $key ".d/*"  | nindent 4 }}
     {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -290,100 +290,108 @@ dashboards:
 plugins: []
 # - fluent-plugin-out-http
 
+defaultConfigs:
+  prometheusConf:
+    enabled: true
+  systemdConf:
+    enabled: false
+
 ## Add fluentd config files from K8s configMaps
 ##
 configMapConfigs:
-  - fluentd-prometheus-conf
-# - fluentd-systemd-conf
+# - 01_sources.conf
+# - 02_filters.conf
+# - 03_dispatch.conf
+# - 04_outputs.conf
 
 ## Fluentd configurations:
 ##
 fileConfigs:
-  01_sources.conf: |-
-    ## logs from podman
-    <source>
-      @type tail
-      @id in_tail_container_logs
-      @label @KUBERNETES
-      path /var/log/containers/*.log
-      pos_file /var/log/fluentd-containers.log.pos
-      tag kubernetes.*
-      read_from_head true
-      <parse>
-        @type multi_format
-        <pattern>
-          format json
-          time_key time
-          time_type string
-          time_format "%Y-%m-%dT%H:%M:%S.%NZ"
-          keep_time_key false
-        </pattern>
-        <pattern>
-          format regexp
-          expression /^(?<time>.+) (?<stream>stdout|stderr)( (.))? (?<log>.*)$/
-          time_format '%Y-%m-%dT%H:%M:%S.%NZ'
-          keep_time_key false
-        </pattern>
-      </parse>
-      emit_unmatched_lines true
-    </source>
+  - 01_sources.conf: |-
+      ## logs from podman
+      <source>
+        @type tail
+        @id in_tail_container_logs
+        @label @KUBERNETES
+        path /var/log/containers/*.log
+        pos_file /var/log/fluentd-containers.log.pos
+        tag kubernetes.*
+        read_from_head true
+        <parse>
+          @type multi_format
+          <pattern>
+            format json
+            time_key time
+            time_type string
+            time_format "%Y-%m-%dT%H:%M:%S.%NZ"
+            keep_time_key false
+          </pattern>
+          <pattern>
+            format regexp
+            expression /^(?<time>.+) (?<stream>stdout|stderr)( (.))? (?<log>.*)$/
+            time_format '%Y-%m-%dT%H:%M:%S.%NZ'
+            keep_time_key false
+          </pattern>
+        </parse>
+        emit_unmatched_lines true
+      </source>
 
-  02_filters.conf: |-
-    <label @KUBERNETES>
-      <match kubernetes.var.log.containers.fluentd**>
-        @type relabel
-        @label @FLUENT_LOG
-      </match>
+  - 02_filters.conf: |-
+      <label @KUBERNETES>
+        <match kubernetes.var.log.containers.fluentd**>
+          @type relabel
+          @label @FLUENT_LOG
+        </match>
 
-      # <match kubernetes.var.log.containers.**_kube-system_**>
-      #   @type null
-      #   @id ignore_kube_system_logs
-      # </match>
+        # <match kubernetes.var.log.containers.**_kube-system_**>
+        #   @type null
+        #   @id ignore_kube_system_logs
+        # </match>
 
-      <filter kubernetes.**>
-        @type kubernetes_metadata
-        @id filter_kube_metadata
-        skip_labels false
-        skip_container_metadata false
-        skip_namespace_metadata true
-        skip_master_url true
-      </filter>
+        <filter kubernetes.**>
+          @type kubernetes_metadata
+          @id filter_kube_metadata
+          skip_labels false
+          skip_container_metadata false
+          skip_namespace_metadata true
+          skip_master_url true
+        </filter>
 
-      <match **>
-        @type relabel
-        @label @DISPATCH
-      </match>
-    </label>
+        <match **>
+          @type relabel
+          @label @DISPATCH
+        </match>
+      </label>
 
-  03_dispatch.conf: |-
-    <label @DISPATCH>
-      <filter **>
-        @type prometheus
-        <metric>
-          name fluentd_input_status_num_records_total
-          type counter
-          desc The total number of incoming records
-          <labels>
-            tag ${tag}
-            hostname ${hostname}
-          </labels>
-        </metric>
-      </filter>
+  - 03_dispatch.conf: |-
+      <label @DISPATCH>
+        <filter **>
+          @type prometheus
+          <metric>
+            name fluentd_input_status_num_records_total
+            type counter
+            desc The total number of incoming records
+            <labels>
+              tag ${tag}
+              hostname ${hostname}
+            </labels>
+          </metric>
+        </filter>
 
-      <match **>
-        @type relabel
-        @label @OUTPUT
-      </match>
-    </label>
+        <match **>
+          @type relabel
+          @label @OUTPUT
+        </match>
+      </label>
 
-  04_outputs.conf: |-
-    <label @OUTPUT>
-      <match **>
-        @type elasticsearch
-        host "elasticsearch-master"
-        port 9200
-        path ""
-        user elastic
-        password changeme
-      </match>
-    </label>
+  - 04_outputs.conf: |-
+      <label @OUTPUT>
+        <match **>
+          @type elasticsearch
+          host "elasticsearch-master"
+          port 9200
+          path ""
+          user elastic
+          password changeme
+        </match>
+      </label>

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -280,7 +280,7 @@ metrics:
 ## Grafana Monitoring Dashboard
 ##
 dashboards:
-  enabled: "true"
+  enabled: true
   namespace: ""
   labels:
     grafana_dashboard: '"1"'


### PR DESCRIPTION
Hi, I want to use FluentD but only for forwarded logs/metrics from FluentBit. So I don't want to use and have the default configuration for systemd and prometheus deployed in my K8s (my FluentD will consume data only by forward input plugin).

I made some changes that will allow to disable deploying of default configuration manifest an also keeps original functionality from default `values.yaml`. 

- [x] Fixed datatype of `dashboards.enabled` parameter
- [x] Hardcoded configmaps `fluentd-prometheus-conf` and `fluentd-systemd-conf` can be now disabled
- [x] `fileConfigs` parameter changed from **_map_** to **_array_** (allows you to insert different configuration fields here, but exclude the original one hardcoded)  

Can you review it and tell if here is something wrong or out of yours vision? @edsiper @dioguerra 