### PR TITLE
feat: adds support for grafana dashboard label value

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.26.0
+version: 0.27.0
 appVersion: 2.0.11
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated Fluent Bit image to v2.0.11"
+    - kind: added
+      description: "Added support for modifying the Grafana dashboard label value."

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "fluent-bit.labels" $ | nindent 4 }}
-    {{ .Values.dashboards.labelKey }}: {{ .Values.dashboards.labelValue | quote }}
+    {{ $.Values.dashboards.labelKey }}: {{ $.Values.dashboards.labelValue | quote }}
 data:
   {{ base $path }}: |
     {{- tpl ($.Files.Get $path) $ | nindent 4 }}

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "fluent-bit.labels" $ | nindent 4 }}
-    {{ $.Values.dashboards.labelKey }}: "1"
+    {{ .Values.dashboards.labelKey }}: {{ .Values.dashboards.labelValue | quote }}
 data:
   {{ base $path }}: |
     {{- tpl ($.Files.Get $path) $ | nindent 4 }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -167,6 +167,7 @@ prometheusRule:
 dashboards:
   enabled: false
   labelKey: grafana_dashboard
+  labelValue: 1
   annotations: {}
   namespace: ""
 


### PR DESCRIPTION
Supports user defined value for the Grafana dashboard label. Adds feature parity with the fluentd chart, to support non-standard values.
Backwards compatable default value of the string value "1".

This should close #332