### PR TITLE
Add topology constraints to fluentbit chart

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.28.0
+version: 0.29.0
 appVersion: 2.1.2
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -7,7 +7,6 @@ keywords:
   - fluentd
 version: 0.41.0
 appVersion: 2.2.0
-
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
 
-version: 0.30.3
+version: 0.31.0
 appVersion: 2.1.4
 
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -136,10 +136,10 @@ tolerations:
 {{- with .Values.topologySpreadConstraints }}
 topologySpreadConstraints:
   {{- range . }}
-  - {{- . | toYaml | nindent 4 }}
+  - {{ . | toYaml | indent 4 | trim}}
     labelSelector:
       matchLabels:
-        {{- include "fluent-bit.selectorLabels" $ | nindent 6 }}
+        {{- include "fluent-bit.selectorLabels" $ | nindent 8 }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -133,4 +133,8 @@ affinity:
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.topologySpreadConstraints}}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end -}}

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -133,8 +133,13 @@ affinity:
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .Values.topologySpreadConstraints}}
+{{- with .Values.topologySpreadConstraints }}
 topologySpreadConstraints:
-  {{- toYaml . | nindent 2 }}
+  {{- range . }}
+  - {{- . | toYaml | nindent 4 }}
+    labelSelector:
+      matchLabels:
+        {{- include "fluent-bit.selectorLabels" $ | nindent 6 }}
+  {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -499,4 +499,3 @@ hotReload:
     digest:
     pullPolicy: IfNotPresent
   resources: {}
-

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -479,3 +479,11 @@ initContainers: []
 #     command: ['kubectl', 'version']
 
 logLevel: info
+
+topologySpreadConstraints: {}
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/zone
+  #   whenUnsatisfiable: ScheduleAnyway
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -484,6 +484,3 @@ topologySpreadConstraints: {}
   # - maxSkew: 1
   #   topologyKey: kubernetes.io/zone
   #   whenUnsatisfiable: ScheduleAnyway
-  #   labelSelector:
-  #     matchLabels:
-  #       app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
While working with fluentbit, I realised we couldn't specify topology constraints. Using deployment in multiple availability zones, this was a problem, since I couldn't optimise pods creation.

Via this PR, I wish to add the possibility to define this value, when deploying Fluentbit on a pod. The value is `{}` by default, so this won't impact users that don't want to use this feature.

Bumped a minor, as this is backward compatible.