### PR TITLE
feat(fluent-bit): add image reference by digest

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.30.1
+version: 0.30.2
 appVersion: 2.1.4
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Updated autoscale API version to v2"
+      description: "Added image reference by digest."

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -66,7 +66,9 @@ Create the name of the service account to use
 Fluent-bit image with tag/digest
 */}}
 {{- define "fluent-bit.image" -}}
-{{ .repository }}{{ ternary (printf ":%s" (toString .tag)) (printf "@%s" .digest) (empty .digest) }}
+{{- $tag := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
+{{- $digest := ternary "" (printf "@%s" .digest) (empty .digest) -}}
+{{- printf "%s%s%s" .repository $tag $digest -}}
 {{- end -}}
 
 {{/*

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -66,16 +66,8 @@ Create the name of the service account to use
 Fluent-bit image with tag/digest
 */}}
 {{- define "fluent-bit.image" -}}
-{{ .Values.image.repository }}{{ ternary (printf ":%s" (toString (default .Chart.AppVersion .Values.image.tag))) (printf "@%s" .Values.image.digest) (empty .Values.image.digest) }}
+{{ .repository }}{{ ternary (printf ":%s" (toString .tag)) (printf "@%s" .digest) (empty .digest) }}
 {{- end -}}
-
-{{/*
-Fluent-bit test image
-*/}}
-{{- define "fluent-bit.testimage" -}}
-{{ .Values.testFramework.image.repository }}{{ ternary (printf ":%s" (toString .Values.testFramework.image.tag)) (printf "@%s" .Values.testFramework.image.digest) (empty .Values.testFramework.image.digest) }}
-{{- end -}}
-
 
 {{/*
 Ingress ApiVersion according k8s version

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -63,6 +63,21 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Fluent-bit image with tag/digest
+*/}}
+{{- define "fluent-bit.image" -}}
+{{ .Values.image.repository }}{{ ternary (printf ":%s" (toString (default .Chart.AppVersion .Values.image.tag))) (printf "@%s" .Values.image.digest) (empty .Values.image.digest) }}
+{{- end -}}
+
+{{/*
+Fluent-bit test image
+*/}}
+{{- define "fluent-bit.testimage" -}}
+{{ .Values.testFramework.image.repository }}{{ ternary (printf ":%s" (toString .Values.testFramework.image.tag)) (printf "@%s" .Values.testFramework.image.digest) (empty .Values.testFramework.image.digest) }}
+{{- end -}}
+
+
+{{/*
 Ingress ApiVersion according k8s version
 */}}
 {{- define "fluent-bit.ingress.apiVersion" -}}

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -38,7 +38,7 @@ containers:
     securityContext:
       {{- toYaml . | nindent 6 }}
   {{- end }}
-    image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+    image: {{ include "fluent-bit.image" . | quote }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if or .Values.env .Values.envWithTpl }}
     env:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -38,7 +38,7 @@ containers:
     securityContext:
       {{- toYaml . | nindent 6 }}
   {{- end }}
-    image: {{ include "fluent-bit.image" . | quote }}
+    image: {{ include "fluent-bit.image" (merge .Values.image (dict "tag" (default .Chart.AppVersion .Values.image.tag))) | quote }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if or .Values.env .Values.envWithTpl }}
     env:

--- a/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: {{ include "fluent-bit.testimage" . | quote }}
+      image: {{ include "fluent-bit.image" .Values.testFramework.image | quote }}
       imagePullPolicy: {{ .Values.testFramework.image.pullPolicy }}
       command: ['wget']
       args: ['{{ include "fluent-bit.fullname" . }}:{{ .Values.service.port }}']

--- a/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: "{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
+      image: {{ include "fluent-bit.testimage" . | quote }}
       imagePullPolicy: {{ .Values.testFramework.image.pullPolicy }}
       command: ['wget']
       args: ['{{ include "fluent-bit.fullname" . }}:{{ .Values.service.port }}']

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -10,6 +10,8 @@ image:
   repository: cr.fluentbit.io/fluent/fluent-bit
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
   tag: ""
+  # Digest overrides tag
+  digest: ""
   pullPolicy: Always
 
 testFramework:
@@ -18,6 +20,8 @@ testFramework:
     repository: busybox
     pullPolicy: Always
     tag: latest
+    # Digest overrides tag
+    digest: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -9,8 +9,7 @@ replicaCount: 1
 image:
   repository: cr.fluentbit.io/fluent/fluent-bit
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: ""
-  # Digest overrides tag
+  tag: ""  # Set to "-" to not use the default value
   digest: ""
   pullPolicy: Always
 
@@ -20,7 +19,6 @@ testFramework:
     repository: busybox
     pullPolicy: Always
     tag: latest
-    # Digest overrides tag
     digest: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
Related to #356 

- Adds ability to reference images using image digest rather than tag.