### PR TITLE
feat(fluentd): add annotations to configs / dashboards

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: v1.15.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/configmap-dashboards.yaml
+++ b/charts/fluentd/templates/configmap-dashboards.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- range $key, $val := $.Values.dashboards.labels }}
     {{ $key }}: {{ $val }}
     {{- end }}
+  {{- with $.Values.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{- end }}
 data:
   {{ base $path }}: |-
     {{- $.Files.Get $path | nindent 4 }}

--- a/charts/fluentd/templates/files.conf/prometheus.yaml
+++ b/charts/fluentd/templates/files.conf/prometheus.yaml
@@ -4,6 +4,10 @@ metadata:
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
   name: fluentd-prometheus-conf-{{ include "fluentd.shortReleaseName" . }}
+  {{- with .Values.configs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{- end }}
 data:
   prometheus.conf: |-
     <source>

--- a/charts/fluentd/templates/files.conf/systemd.yaml
+++ b/charts/fluentd/templates/files.conf/systemd.yaml
@@ -4,6 +4,10 @@ metadata:
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
   name: fluentd-systemd-conf-{{ include "fluentd.shortReleaseName" . }}
+  {{- with .Values.configs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{- end }}
 data:
   systemd.conf: |-
     <source>

--- a/charts/fluentd/templates/fluentd-configurations-cm.yaml
+++ b/charts/fluentd/templates/fluentd-configurations-cm.yaml
@@ -6,6 +6,10 @@ metadata:
   name: fluentd-config-{{ include "fluentd.shortReleaseName" . }}
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
+  {{- with .Values.configs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{- end }}
 data:
 {{- range $key, $value := .Values.fileConfigs }}
   {{$key }}: |-
@@ -21,6 +25,10 @@ metadata:
   name: fluentd-main-{{ include "fluentd.shortReleaseName" . }}
   labels:
     {{- include "fluentd.labels" . | nindent 4 }}
+  {{- with .Values.configs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{- end }}
 data:
   fluent.conf: |-
     # do not collect fluentd logs to avoid infinite loops.

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -272,11 +272,17 @@ dashboards:
   namespace: ""
   labels:
     grafana_dashboard: '"1"'
+  annotations: {}
 
 ## Fluentd list of plugins to install
 ##
 plugins: []
 # - fluent-plugin-out-http
+
+## Settings for configMapConfigs and fileConfigs
+##
+configs:
+  annotations: {}
 
 ## Add fluentd config files from K8s configMaps
 ##


### PR DESCRIPTION
Closes #357 

Fluentd chart:
- Adds a new value: `configs.annotations: {}`.  When set, the configMapConfigs and fileConfigs will have annotations applied.
- Adds a new value: `dashboards.annotations: {}`.  When set, the dashboard config will have annotations applied.