### PR TITLE
feat(fluent-operator): add image reference by digest

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.2.0
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg
 home: https://www.fluentd.org/

--- a/charts/fluent-operator/templates/_helpers.tpl
+++ b/charts/fluent-operator/templates/_helpers.tpl
@@ -66,5 +66,7 @@ Create the name of the service account to use
 Fluentbit operator image with tag/digest
 */}}
 {{- define "fluentbit-operator.image" -}}
-{{ .repository }}{{ ternary (printf ":%s" (toString .tag)) (printf "@%s" .digest) (empty .digest) }}
+{{- $tag := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
+{{- $digest := ternary "" (printf "@%s" .digest) (empty .digest) -}}
+{{- printf "%s%s%s" .repository $tag $digest -}}
 {{- end -}}

--- a/charts/fluent-operator/templates/_helpers.tpl
+++ b/charts/fluent-operator/templates/_helpers.tpl
@@ -61,3 +61,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Fluentbit operator image with tag/digest
+*/}}
+{{- define "fluentbit-operator.image" -}}
+{{ .repository }}{{ ternary (printf ":%s" (toString .tag)) (printf "@%s" .digest) (empty .digest) }}
+{{- end -}}

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         emptyDir: {}
       initContainers:
       - name: setenv
-        image: {{ .Values.operator.initcontainer.repository }}{{ ternary (printf ":%s" (toString .Values.operator.initcontainer.tag)) (printf "@%s" .Values.operator.initcontainer.digest) (empty .Values.operator.initcontainer.digest) }}
+        image: {{ include "fluentbit-operator.image" .Values.operator.initcontainer }}
         command:
         - /bin/sh
         - '-c'
@@ -67,7 +67,7 @@ spec:
           emptyDir: {}
       initContainers:
       - name: setenv
-        image: {{ .Values.operator.initcontainer.repository }}{{ ternary (printf ":%s" (toString .Values.operator.initcontainer.tag)) (printf "@%s" .Values.operator.initcontainer.digest) (empty .Values.operator.initcontainer.digest) }}
+        image: {{ include "fluentbit-operator.image" .Values.operator.initcontainer }}
         command:
         - /bin/sh
         - '-c'
@@ -79,7 +79,7 @@ spec:
       {{- end }}
       containers:
       - name: fluent-operator
-        image: {{ .Values.operator.container.repository }}{{ ternary (printf ":%s" (toString .Values.operator.container.tag)) (printf "@%s" .Values.operator.container.digest) (empty .Values.operator.container.digest) }}
+        image: {{ include "fluentbit-operator.image" .Values.operator.container }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}
         env:

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           path: /var/run/docker.sock
       initContainers:
       - name: setenv
-        image: {{ .Values.operator.initcontainer.repository }}:{{ .Values.operator.initcontainer.tag }}
+        image: {{ include "fluentbit-operator.image" .Values.operator.initcontainer }}
         command:
         - /bin/sh
         - '-c'
@@ -52,7 +52,7 @@ spec:
         emptyDir: {}
       initContainers:
       - name: setenv
-        image: {{ .Values.operator.initcontainer.repository }}:{{ .Values.operator.initcontainer.tag }}
+        image: {{ .Values.operator.initcontainer.repository }}{{ ternary (printf ":%s" (toString .Values.operator.initcontainer.tag)) (printf "@%s" .Values.operator.initcontainer.digest) (empty .Values.operator.initcontainer.digest) }}
         command:
         - /bin/sh
         - '-c'
@@ -67,7 +67,7 @@ spec:
           emptyDir: {}
       initContainers:
       - name: setenv
-        image: {{ .Values.operator.initcontainer.repository }}:{{ .Values.operator.initcontainer.tag }}
+        image: {{ .Values.operator.initcontainer.repository }}{{ ternary (printf ":%s" (toString .Values.operator.initcontainer.tag)) (printf "@%s" .Values.operator.initcontainer.digest) (empty .Values.operator.initcontainer.digest) }}
         command:
         - /bin/sh
         - '-c'
@@ -79,7 +79,7 @@ spec:
       {{- end }}
       containers:
       - name: fluent-operator
-        image: {{ .Values.operator.container.repository }}:{{ .Values.operator.container.tag }}
+        image: {{ .Values.operator.container.repository }}{{ ternary (printf ":%s" (toString .Values.operator.container.tag)) (printf "@%s" .Values.operator.container.digest) (empty .Values.operator.container.digest) }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}
         env:

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
+  image: {{ include "fluentbit-operator.image" .Values.fluentbit.image }}
   {{- if .Values.fluentbit.imagePullSecrets }}
   imagePullSecrets:
 {{ toYaml .Values.fluentbit.imagePullSecrets | indent 4 }}

--- a/charts/fluent-operator/templates/fluentbit-fluentbit-edge.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentbit-edge.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
+  image: {{ include "fluentbit-operator.image" .Values.fluentbit.image }}
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -12,7 +12,7 @@ spec:
         bind: 0.0.0.0
         port: {{ .Values.fluentd.port }}
   replicas: {{ .Values.fluentd.replicas }}
-  image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}
+  image: {{ include "fluentbit-operator.image" .Values.fluentd.image }}
   resources:
   {{- toYaml .Values.fluentd.resources | nindent 4  }}
   fluentdCfgSelector:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -14,9 +14,13 @@ operator:
   initcontainer:
     repository: "docker"
     tag: "20.10"
+    # Digest overrides tag
+    digest: ""
   container:
     repository: "kubesphere/fluent-operator"
     tag: "v2.2.0"
+    # Digest overrides tag
+    digest: ""
     # FluentBit operator resources. Usually user needn't to adjust these.
   resources:
     limits:
@@ -54,6 +58,8 @@ fluentbit:
   image:
     repository: "kubesphere/fluent-bit"
     tag: "v2.0.11"
+    # Digest overrides tag
+    digest: ""
   # fluentbit resources. If you do want to specify resources, adjust them as necessary
   # You can adjust it based on the log volume.
   resources:
@@ -197,6 +203,8 @@ fluentd:
   image:
     repository: "kubesphere/fluentd"
     tag: "v1.15.3"
+    # Digest overrides tag
+    digest: ""
   replicas: 1
   forward:
     port: 24224

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -14,12 +14,10 @@ operator:
   initcontainer:
     repository: "docker"
     tag: "20.10"
-    # Digest overrides tag
     digest: ""
   container:
     repository: "kubesphere/fluent-operator"
     tag: "v2.2.0"
-    # Digest overrides tag
     digest: ""
     # FluentBit operator resources. Usually user needn't to adjust these.
   resources:
@@ -58,7 +56,6 @@ fluentbit:
   image:
     repository: "kubesphere/fluent-bit"
     tag: "v2.0.11"
-    # Digest overrides tag
     digest: ""
   # fluentbit resources. If you do want to specify resources, adjust them as necessary
   # You can adjust it based on the log volume.
@@ -203,7 +200,6 @@ fluentd:
   image:
     repository: "kubesphere/fluentd"
     tag: "v1.15.3"
-    # Digest overrides tag
     digest: ""
   replicas: 1
   forward:


### PR DESCRIPTION
Related to #356 

Add ability to reference images by digest to fluent-operator Helm chart.  Digest will override tag.