### PR TITLE
feat(fluentd): add image reference by digest

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: v1.15.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -90,3 +90,10 @@ Name of the configMap used for additional configuration files; allows users to o
     {{ printf "%s-%s" "fluentd-config" ( include "fluentd.shortReleaseName" . ) }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Fluentd image with tag/digest
+*/}}
+{{- define "fluentd.image" -}}
+{{ .repository }}{{ ternary (printf ":%s" (toString .tag)) (printf "@%s" .digest) (empty .digest) }}
+{{- end -}}

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -95,5 +95,7 @@ Name of the configMap used for additional configuration files; allows users to o
 Fluentd image with tag/digest
 */}}
 {{- define "fluentd.image" -}}
-{{ .repository }}{{ ternary (printf ":%s" (toString .tag)) (printf "@%s" .digest) (empty .digest) }}
+{{- $tag := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
+{{- $digest := ternary "" (printf "@%s" .digest) (empty .digest) -}}
+{{- printf "%s%s%s" .repository $tag $digest -}}
 {{- end -}}

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -21,7 +21,7 @@ containers:
   - name: {{ .Chart.Name }}
     securityContext:
       {{- toYaml .Values.securityContext | nindent 6 }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default $defaultTag }}"
+    image: {{ include "fluentd.image" (merge .Values.image (dict "tag" (default $defaultTag .Values.image.tag))) }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if .Values.plugins }}
     command:

--- a/charts/fluentd/templates/tests/test-connection.yaml
+++ b/charts/fluentd/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testFramework.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -9,7 +10,13 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: {{ include "fluentd.image" .Values.testFramework.image }}
+      imagePullPolicy: {{ .Values.testFramework.image.pullPolicy }}
       command: ['wget']
-      args: ['{{ include "fluentd.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "fluentd.fullname" . }}:24231/metrics']
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never
+{{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -11,6 +11,17 @@ image:
   repository: "fluent/fluentd-kubernetes-daemonset"
   pullPolicy: "IfNotPresent"
   tag: ""
+  # Digest overrides tag
+  digest: ""
+
+testFramework:
+  enabled: true
+  image:
+    repository: busybox
+    pullPolicy: Always
+    tag: latest
+    # Digest overrides tag
+    digest: ""
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -10,7 +10,7 @@ kind: "DaemonSet"
 image:
   repository: "fluent/fluentd-kubernetes-daemonset"
   pullPolicy: "IfNotPresent"
-  tag: "" # Set to "-" to not use the default value
+  tag: ""  # Set to "-" to not use the default value
   digest: ""
 
 testFramework:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -10,8 +10,7 @@ kind: "DaemonSet"
 image:
   repository: "fluent/fluentd-kubernetes-daemonset"
   pullPolicy: "IfNotPresent"
-  tag: ""
-  # Digest overrides tag
+  tag: "" # Set to "-" to not use the default value
   digest: ""
 
 testFramework:
@@ -20,7 +19,6 @@ testFramework:
     repository: busybox
     pullPolicy: Always
     tag: latest
-    # Digest overrides tag
     digest: ""
 
 ## Optional array of imagePullSecrets containing private registry credentials


### PR DESCRIPTION
Related to #356 

Adds ability to reference images by digest.  Digest will override tag.

Also fixed fluentd test.
Closes: https://github.com/fluent/helm-charts/issues/440