### PR TITLE
feat(fluentd): reduce permissions on configmap volumes

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: v1.15.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -51,11 +51,9 @@ The default configurations bellow are required for the fluentd pod to be able to
 - name: etcfluentd-main
   configMap:
     name: fluentd-main
-    defaultMode: 0777
 - name: etcfluentd-config
   configMap:
     name: fluentd-config
-    defaultMode: 0777
 ```
 
 ### default-volumeMounts

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -91,11 +91,9 @@ volumes:
 - name: etcfluentd-main
   configMap:
     name: {{ include "fluentd.mainConfigMapName" . }}
-    defaultMode: 0777
 - name: etcfluentd-config
   configMap:
     name: {{ include "fluentd.extraFilesConfigMapName" . }}
-    defaultMode: 0777
 {{- if .Values.mountVarLogDirectory }}
 - name: varlog
   hostPath:
@@ -113,7 +111,6 @@ volumes:
 {{- print "- name: " $key | nindent 0 }}
   configMap:
     {{- print "name: " $key "-" ( include "fluentd.shortReleaseName" $ ) | nindent 4 }}
-    defaultMode: 0777
 {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:


### PR DESCRIPTION
Removes `defaultmode` from config map volume mounts.  The default of 0644 will be used instead.  For configmaps, Kubernetes automatically makes them read-only, so the effective permission is 0444 (read-only for everyone).  The previous value was 0777 (read/write/executable for everyone)

Closes #365 