### PR TITLE
feat(fluentd): add support for templating volumes and initcontainers

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: v1.15.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -15,7 +15,7 @@ terminationGracePeriodSeconds: {{ . }}
 {{- end }}
 {{- with .Values.initContainers }}
 initContainers:
-  {{- toYaml . | nindent 2 }}
+  {{- tpl (ternary . (toYaml .) (kindIs "string" .)) $ | trim | nindent 2 -}}
 {{- end }}
 containers:
   - name: {{ .Chart.Name }}
@@ -76,8 +76,8 @@ containers:
       mountPath: /var/lib/docker/containers
       readOnly: true
     {{- end }}
-    {{- if .Values.volumeMounts -}}
-    {{- toYaml .Values.volumeMounts | nindent 4 }}
+    {{- with .Values.volumeMounts -}}
+    {{- tpl (ternary . (toYaml .) (kindIs "string" .)) $ | trim | nindent 4 -}}
     {{- end -}}
     {{- range $key := .Values.configMapConfigs }}
     {{- print "- name: " $key | nindent 4 }}
@@ -106,8 +106,8 @@ volumes:
   hostPath:
     path: /var/lib/docker/containers
 {{- end }}
-{{- if .Values.volumes -}}
-{{- toYaml .Values.volumes | nindent 0 }}
+{{- with .Values.volumes -}}
+{{- tpl (ternary . (toYaml .) (kindIs "string" .)) $ | trim | nindent 0 -}}
 {{- end -}}
 {{- range $key := .Values.configMapConfigs }}
 {{- print "- name: " $key | nindent 0 }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/fluentd-configurations-cm.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (ternary . (toYaml .) (kindIs "string" .)) $ | trim | nindent 8 }}
         {{- end }}
       labels:
         {{- include "fluentd.selectorLabels" . | nindent 8 }}

--- a/charts/fluentd/templates/deployment.yaml
+++ b/charts/fluentd/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/fluentd-configurations-cm.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (ternary . (toYaml .) (kindIs "string" .)) $ | trim | nindent 8 }}
         {{- end }}
       labels:
         {{- include "fluentd.selectorLabels" . | nindent 8 }}

--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/fluentd-configurations-cm.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (ternary . (toYaml .) (kindIs "string" .)) $ | trim | nindent 8 }}
         {{- end }}
       labels:
         {{- include "fluentd.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
Closes #371 

- Adds support for Helm templating in volumes, volumeMounts, and initContainers.
- Changes are backwards compatible with using literal values for these keys