### PR TITLE
Improve Openshift support, allow to use existing SCCs

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.30.3
+version: 0.31.0
 appVersion: 2.1.4
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Use .Release.Namespace to render namespace for the fluent-bit resources."
+      description: "Ability to use existing SecurityContextConstraints, when running in Openshift"

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -29,13 +29,17 @@ rules:
     verbs:
       - use
   {{- end }}
-  {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+  {{- if .Values.openshift.enabled }}
   - apiGroups:
       - security.openshift.io
     resources:
       - securitycontextconstraints
     resourceNames:
+      {{- if .Values.openshift.securityContextConstraints.create }}
       - {{ include "fluent-bit.fullname" . }}
+      {{- else }}
+      - {{ .Values.openshift.securityContextConstraints.name }}
+      {{- end }}
     verbs:
       - use
   {{- end }}

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -1,12 +1,14 @@
-{{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+{{- if and .Values.openshift.enabled .Values.openshift.securityContextConstraints.create }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-{{- if .Values.openShift.securityContextConstraints.annotations }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+  {{- with .Values.openshift.securityContextConstraints.annotations }}
   annotations:
-    {{- toYaml .Values.openShift.securityContextConstraints.annotations | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 allowPrivilegedContainer: true
 allowPrivilegeEscalation: true
 allowHostDirVolumePlugin: true
@@ -30,8 +32,10 @@ supplementalGroups:
   type: RunAsAny
 volumes:
   - configMap
+  - downwardAPI
   - emptyDir
   - hostPath
   - persistentVolumeClaim
+  - projected
   - secret
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   repository: cr.fluentbit.io/fluent/fluent-bit
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: ""  # Set to "-" to not use the default value
+  tag: "" # Set to "-" to not use the default value
   digest: ""
   pullPolicy: Always
 
@@ -44,13 +44,15 @@ podSecurityPolicy:
   create: false
   annotations: {}
 
-openShift:
+openshift:
   # Sets Openshift support
   enabled: false
   # Creates SCC for Fluent-bit when Openshift support is enabled
   securityContextConstraints:
-    create: true
+    create: false
     annotations: {}
+    # Allows user to use any existing SCC in cluster
+    name: "privileged"
 
 podSecurityContext: {}
 #   fsGroup: 2000
@@ -98,31 +100,31 @@ service:
 
 serviceMonitor:
   enabled: false
-#   namespace: monitoring
-#   interval: 10s
-#   scrapeTimeout: 10s
-#   jobLabel: fluentbit
-#   selector:
-#    prometheus: my-prometheus
-#  ## metric relabel configs to apply to samples before ingestion.
-#  ##
-#  metricRelabelings:
-#    - sourceLabels: [__meta_kubernetes_service_label_cluster]
-#      targetLabel: cluster
-#      regex: (.*)
-#      replacement: ${1}
-#      action: replace
-#  ## relabel configs to apply to samples after ingestion.
-#  ##
-#  relabelings:
-#    - sourceLabels: [__meta_kubernetes_pod_node_name]
-#      separator: ;
-#      regex: ^(.*)$
-#      targetLabel: nodename
-#      replacement: $1
-#      action: replace
-#  scheme: ""
-#  tlsConfig: {}
+  #   namespace: monitoring
+  #   interval: 10s
+  #   scrapeTimeout: 10s
+  #   jobLabel: fluentbit
+  #   selector:
+  #    prometheus: my-prometheus
+  #  ## metric relabel configs to apply to samples before ingestion.
+  #  ##
+  #  metricRelabelings:
+  #    - sourceLabels: [__meta_kubernetes_service_label_cluster]
+  #      targetLabel: cluster
+  #      regex: (.*)
+  #      replacement: ${1}
+  #      action: replace
+  #  ## relabel configs to apply to samples after ingestion.
+  #  ##
+  #  relabelings:
+  #    - sourceLabels: [__meta_kubernetes_pod_node_name]
+  #      separator: ;
+  #      regex: ^(.*)$
+  #      targetLabel: nodename
+  #      replacement: $1
+  #      action: replace
+  #  scheme: ""
+  #  tlsConfig: {}
 
   ## Beare in mind if youn want to collec metrics from a different port
   ## you will need to configure the new ports on the extraPorts property.
@@ -175,9 +177,9 @@ dashboards:
   namespace: ""
 
 lifecycle: {}
-  # preStop:
-  #   exec:
-  #     command: ["/bin/sh", "-c", "sleep 20"]
+# preStop:
+#   exec:
+#     command: ["/bin/sh", "-c", "sleep 20"]
 
 livenessProbe:
   httpGet:
@@ -202,13 +204,13 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts: []
   # - host: fluent-bit.example.tld
   extraHosts: []
   # - host: fluent-bit-extra.example.tld
-      ## specify extraPort number
+  ## specify extraPort number
   #   port: 5170
   tls: []
   #  - secretName: fluent-bit-example-tld
@@ -243,17 +245,17 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 75
-#  targetMemoryUtilizationPercentage: 75
-   ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
+  #  targetMemoryUtilizationPercentage: 75
+  ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
   customRules: []
-#     - type: Pods
-#       pods:
-#         metric:
-#           name: packets-per-second
-#         target:
-#           type: AverageValue
-#           averageValue: 1k
-    ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+  #     - type: Pods
+  #       pods:
+  #         metric:
+  #           name: packets-per-second
+  #         target:
+  #           type: AverageValue
+  #           averageValue: 1k
+  ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
   behavior: {}
 #      scaleDown:
 #        policies:
@@ -433,34 +435,34 @@ config:
 
 # The config volume is mounted by default, either to the existingConfigMap value, or the default of "fluent-bit.fullname"
 volumeMounts:
-  - name: config
-    mountPath: /fluent-bit/etc/fluent-bit.conf
-    subPath: fluent-bit.conf
-  - name: config
-    mountPath: /fluent-bit/etc/custom_parsers.conf
-    subPath: custom_parsers.conf
+- name: config
+  mountPath: /fluent-bit/etc/fluent-bit.conf
+  subPath: fluent-bit.conf
+- name: config
+  mountPath: /fluent-bit/etc/custom_parsers.conf
+  subPath: custom_parsers.conf
 
 daemonSetVolumes:
-  - name: varlog
-    hostPath:
-      path: /var/log
-  - name: varlibdockercontainers
-    hostPath:
-      path: /var/lib/docker/containers
-  - name: etcmachineid
-    hostPath:
-      path: /etc/machine-id
-      type: File
+- name: varlog
+  hostPath:
+    path: /var/log
+- name: varlibdockercontainers
+  hostPath:
+    path: /var/lib/docker/containers
+- name: etcmachineid
+  hostPath:
+    path: /etc/machine-id
+    type: File
 
 daemonSetVolumeMounts:
-  - name: varlog
-    mountPath: /var/log
-  - name: varlibdockercontainers
-    mountPath: /var/lib/docker/containers
-    readOnly: true
-  - name: etcmachineid
-    mountPath: /etc/machine-id
-    readOnly: true
+- name: varlog
+  mountPath: /var/log
+- name: varlibdockercontainers
+  mountPath: /var/lib/docker/containers
+  readOnly: true
+- name: etcmachineid
+  mountPath: /etc/machine-id
+  readOnly: true
 
 args: []
 


### PR DESCRIPTION
- Add ability to provide existing SecurityContextConstraints name instead of create new one
- Add ability to add annotations for SecrutiryContextConstraints resource, created with the chart
- Add common labels for SecurityContextConstraints
- Improve variables naming