### PR TITLE
[Fluent-Bit] Improve Openshift support, allow to use existing SCCs

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.34.0
+version: 0.34.1
 appVersion: 2.1.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,9 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated Grafana dashboard to be scoped to release and general Grafana component improvements."
-    - kind: changed
-      description: "Changed the ServiceMonitor job name to the release name for consistency."
-    - kind: removed
-      description: "Removed serviceMonitor.jobLabel value as it was being incorrectly used and this should be a static value."
+    - kind: added
+      description: "Add ability to use existing SecurityContextConstraints in OpenShift, for the fluent-bit chart."

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Add ability to use existing SecurityContextConstraints in OpenShift, for the fluent-bit chart."
+      description: "Added support for using an existing SecurityContextConstraints for OpenShift."

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -129,10 +129,10 @@ autoscaling/v2
 {{/*
 Create the name of OpenShift SecurityContextConstraints to use
 */}}
-{{- define "fluent-bit.openShift.securityContextConstraints.name" -}}
-{{- if .Values.openShift.securityContextConstraints.create -}}
-  {{ default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name }}
-{{- else if .Values.openShift.securityContextConstraints.existingName -}}
-  {{- printf "%s" .Values.openShift.securityContextConstraints.existingName -}}
+{{- define "fluent-bit.openShiftSccName" -}}
+{{- if not .Values.openShift.securityContextConstraints.create -}}
+{{- printf "%s" .Values.openShift.securityContextConstraints.existingName -}}
+{{- else -}}
+{{- printf "%s" default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name -}}
 {{- end -}}
 {{- end -}}

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -125,3 +125,14 @@ autoscaling/v2beta2
 autoscaling/v2
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of OpenShift SecurityContextConstraints to use
+*/}}
+{{- define "fluent-bit.openShift.securityContextConstraints.name" -}}
+{{- if .Values.openShift.securityContextConstraints.create -}}
+  {{ default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name }}
+{{- else if .Values.openShift.securityContextConstraints.existingName -}}
+  {{- printf "%s" .Values.openShift.securityContextConstraints.existingName -}}
+{{- end -}}
+{{- end -}}

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -29,13 +29,13 @@ rules:
     verbs:
       - use
   {{- end }}
-  {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+  {{- if .Values.openShift.enabled }}
   - apiGroups:
       - security.openshift.io
     resources:
       - securitycontextconstraints
     resourceNames:
-      - {{ include "fluent-bit.fullname" . }}
+      - {{ include "fluent-bit.openShift.securityContextConstraints.name" . }}
     verbs:
       - use
   {{- end }}

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -35,7 +35,7 @@ rules:
     resources:
       - securitycontextconstraints
     resourceNames:
-      - {{ include "fluent-bit.openShift.securityContextConstraints.name" . }}
+      - {{ include "fluent-bit.openShiftSccName" . }}
     verbs:
       - use
   {{- end }}

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -2,7 +2,7 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "fluent-bit.openShift.securityContextConstraints.name" . }}
+  name: {{ include "fluent-bit.openShiftSccName" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.openShift.securityContextConstraints.annotations }}

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
-apiVersion: security.openShift.io/v1
+apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ include "fluent-bit.openShift.securityContextConstraints.name" . }}
@@ -20,10 +20,10 @@ allowHostPorts: false
 allowHostPID: false
 allowedCapabilities: []
 forbiddenSysctls:
-- "*"
+  - "*"
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
-- MKNOD
+  - MKNOD
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -1,12 +1,14 @@
 {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
-apiVersion: security.openshift.io/v1
+apiVersion: security.openShift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "fluent-bit.fullname" . }}
-{{- if .Values.openShift.securityContextConstraints.annotations }}
+  name: {{ include "fluent-bit.openShift.securityContextConstraints.name" . }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+  {{- with .Values.openShift.securityContextConstraints.annotations }}
   annotations:
-    {{- toYaml .Values.openShift.securityContextConstraints.annotations | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 allowPrivilegedContainer: true
 allowPrivilegeEscalation: true
 allowHostDirVolumePlugin: true
@@ -30,8 +32,10 @@ supplementalGroups:
   type: RunAsAny
 volumes:
   - configMap
+  - downwardAPI
   - emptyDir
   - hostPath
   - persistentVolumeClaim
+  - projected
   - secret
 {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -45,13 +45,16 @@ podSecurityPolicy:
   create: false
   annotations: {}
 
+# OpenShift-specific configuration
 openShift:
-  # Sets Openshift support
   enabled: false
-  # Creates SCC for Fluent-bit when Openshift support is enabled
   securityContextConstraints:
-    create: true
+    # Create SCC for Fluent-bit and allow use it
+    create: false
+    name: ""
     annotations: {}
+    # Use existing SCC in cluster, rather then create new one
+    existingName: ""
 
 podSecurityContext: {}
 #   fsGroup: 2000

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -50,7 +50,7 @@ openShift:
   enabled: false
   securityContextConstraints:
     # Create SCC for Fluent-bit and allow use it
-    create: false
+    create: true
     name: ""
     annotations: {}
     # Use existing SCC in cluster, rather then create new one


### PR DESCRIPTION
- This commit breaks Openshift compatibility with previous versions
- Add ability to provide existing SecurityContextConstraints name instead of create new one
- Add ability to add annotations for SecrutiryContextConstraints resource, created with the chart
- Add common labels for SecurityContextConstraints
- Improve variables naming