### PR TITLE
Fluent Bit: Add support for Templated Lua scripts

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.30.4
+version: 0.30.5
 appVersion: 2.1.4
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -27,7 +27,7 @@ Fluent Bit allows us to build filter to modify the incoming records using custom
 
 ### How to use Lua scripts with this Chart
 
-First, you should add your Lua scripts to `luaScripts` in values.yaml, for example:
+First, you should add your Lua scripts to `luaScripts` or `luaScriptsWithTpl` in values.yaml, for example:
 
 ```yaml
 luaScripts:

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -92,7 +92,7 @@ containers:
         mountPath: /fluent-bit/etc/{{ $key }}
         subPath: {{ $key }}
     {{- end }}
-    {{- range $key, $value := .Values.luaScripts }}
+    {{- range $key, $value := merge .Values.luaScripts .Values.luaScriptsWithTpl }}
       - name: luascripts
         mountPath: /fluent-bit/scripts/{{ $key }}
         subPath: {{ $key }}
@@ -110,7 +110,7 @@ volumes:
   - name: config
     configMap:
       name: {{ if .Values.existingConfigMap }}{{ .Values.existingConfigMap }}{{- else }}{{ include "fluent-bit.fullname" . }}{{- end }}
-{{- if gt (len .Values.luaScripts) 0 }}
+{{- if or (gt (len .Values.luaScripts) 0) (gt (len .Values.luaScriptsWithTpl) 0) }}
   - name: luascripts
     configMap:
       name: {{ include "fluent-bit.fullname" . }}-luascripts

--- a/charts/fluent-bit/templates/configmap-luascripts.yaml
+++ b/charts/fluent-bit/templates/configmap-luascripts.yaml
@@ -1,4 +1,4 @@
-{{- if gt (len .Values.luaScripts) 0 -}}
+{{- if or (gt (len .Values.luaScripts) 0) (gt (len .Values.luaScriptsWithTpl) 0) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,5 +9,9 @@ metadata:
 data:
   {{ range $key, $value := .Values.luaScripts }}
   {{ $key }}: {{ $value | quote }}
+  {{ end }}
+  {{ range $key, $value := .Values.luaScriptsWithTpl }}
+  {{ $key }}: |
+    {{- (tpl $value $) | nindent 4 }}
   {{ end }}
 {{- end -}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -344,6 +344,8 @@ networkPolicy:
 
 luaScripts: {}
 
+luaScriptsWithTpl: {}
+
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file
 config:
   service: |


### PR DESCRIPTION
This change allows to create templated Lua scripts using the new variable `luaScriptsWithTpl` (similar to the `envWithTpl` variable).