### PR TITLE
fix ingressClassName in values.yaml

### DIFF
--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -201,7 +201,7 @@ resources: {}
 ## only available if kind is Deployment
 ingress:
   enabled: false
-  className: ""
+  ingressClassName: ""
   annotations: {}
   #  kubernetes.io/ingress.class: nginx
   #  kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
In the ingress template the value used is `.Values.ingress.ingressClassName` but in the `values.yaml` file the variable was named just `className`, this changes to the correct one