### PR TITLE
Remove duplciated `volumeMounts` in `reloader` container

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.34.0
+version: 0.34.1
 appVersion: 2.1.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,9 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated Grafana dashboard to be scoped to release and general Grafana component improvements."
-    - kind: changed
-      description: "Changed the ServiceMonitor job name to the release name for consistency."
-    - kind: removed
-      description: "Removed serviceMonitor.jobLabel value as it was being incorrectly used and this should be a static value."
+    - kind: fixed
+      description: "Removed duplicated volumeMounts key in reloader container."

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -111,7 +111,6 @@ containers:
     volumeMounts:
       - name: config
         mountPath: /watch/config
-    volumeMounts:
       - name: luascripts
         mountPath: /watch/scripts
     {{- with .Values.hotReload.resources }}


### PR DESCRIPTION
When the chart is deployed with `hotReload.enabled: true`, because of the duplicated `volumeMounts` key only the second block was being picked up:

This:
```yaml
    volumeMounts:
      - name: config
        mountPath: /watch/config
    volumeMounts:
      - name: luascripts
        mountPath: /watch/scripts
```
Would become this:
```yaml
    volumeMounts:
      - name: luascripts
        mountPath: /watch/scripts
```

With this PR the block now looks like this:
```yaml
    volumeMounts:
      - name: config
        mountPath: /watch/config
      - name: luascripts
        mountPath: /watch/scripts
```