### PR TITLE
feature ✨(fluentd): added changes to defaultTag in the _pod.tpl

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -3,14 +3,14 @@ name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
 version: 0.4.3
-appVersion: v1.15.2
+appVersion: v1.16.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/
 sources:
-  - https://github.com/fluent/fluentd/
-  - https://github.com/fluent/fluentd-kubernetes-daemonset
+- https://github.com/fluent/fluentd/
+- https://github.com/fluent/fluentd-kubernetes-daemonset
 maintainers:
-  - name: edsiper
-    email: eduardo@treasure-data.com
-  - name: dioguerra
-    email: diogo.filipe.tomas.guerra@cern.ch
+- name: edsiper
+  email: eduardo@treasure-data.com
+- name: dioguerra
+  email: diogo.filipe.tomas.guerra@cern.ch

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: v1.16.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -1,5 +1,5 @@
 {{- define "fluentd.pod" -}}
-{{- $defaultTag := printf "%s-debian-elasticsearch7-1.0" (.Chart.AppVersion) -}}
+{{- $defaultTag := printf "%s-debian-%s-1.0" (.Chart.AppVersion) (.Values.outputType) -}}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -1,5 +1,5 @@
 {{- define "fluentd.pod" -}}
-{{- $defaultTag := printf "%s-debian-%s-1.0" (.Chart.AppVersion) (.Values.outputType) -}}
+{{- $defaultTag := printf "%s-debian-%s-1.0" (.Chart.AppVersion) (.Values.variant) -}}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -37,23 +37,23 @@ podSecurityPolicy:
 ## notes on enabling and using sysctls
 ##
 podSecurityContext: {}
-# seLinuxOptions:
-#   type: "spc_t"
+  # seLinuxOptions:
+  #   type: "spc_t"
 
 securityContext: {}
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
 # Configure the livecycle
 # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 lifecycle: {}
-# preStop:
-#   exec:
-#     command: ["/bin/sh", "-c", "sleep 20"]
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "sleep 20"]
 
 # Configure the livenessProbe
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -102,16 +102,16 @@ autoscaling:
     #     target:
     #       type: AverageValue
     #       averageValue: 1k
- ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
-    # behavior:
-    #   scaleDown:
-    #     policies:
-    #       - type: Pods
-    #         value: 4
-    #         periodSeconds: 60
-    #       - type: Percent
-    #         value: 10
-    #         periodSeconds: 60
+  ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
+  # behavior:
+  #   scaleDown:
+  #     policies:
+  #       - type: Pods
+  #         value: 4
+  #         periodSeconds: 60
+  #       - type: Percent
+  #         value: 10
+  #         periodSeconds: 60
 
 # priorityClassName: "system-node-critical"
 

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 # DaemonSet, Deployment or StatefulSet
 kind: "DaemonSet"
-# elasticsearch7 elasticsearch8 kinesis cloudwatch azureblob kafka kafka2 gcs graylog 
+# azureblob, cloudwatch, elasticsearch7, elasticsearch8, gcs, graylog , kafka, kafka2, kinesis, opensearch     
 outputType: elasticsearch7
 # # Only applicable for Deployment or StatefulSet
 # replicaCount: 1

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 # DaemonSet, Deployment or StatefulSet
 kind: "DaemonSet"
 # azureblob, cloudwatch, elasticsearch7, elasticsearch8, gcs, graylog , kafka, kafka2, kinesis, opensearch     
-outputType: elasticsearch7
+variant: elasticsearch7
 # # Only applicable for Deployment or StatefulSet
 # replicaCount: 1
 

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -3,7 +3,8 @@ fullnameOverride: ""
 
 # DaemonSet, Deployment or StatefulSet
 kind: "DaemonSet"
-
+# elasticsearch7 elasticsearch8 kinesis cloudwatch azureblob kafka kafka2 gcs graylog 
+outputType: elasticsearch7
 # # Only applicable for Deployment or StatefulSet
 # replicaCount: 1
 
@@ -36,23 +37,23 @@ podSecurityPolicy:
 ## notes on enabling and using sysctls
 ##
 podSecurityContext: {}
-  # seLinuxOptions:
-  #   type: "spc_t"
+# seLinuxOptions:
+#   type: "spc_t"
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 # Configure the livecycle
 # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 lifecycle: {}
-  # preStop:
-  #   exec:
-  #     command: ["/bin/sh", "-c", "sleep 20"]
+# preStop:
+#   exec:
+#     command: ["/bin/sh", "-c", "sleep 20"]
 
 # Configure the livenessProbe
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -60,11 +61,11 @@ livenessProbe:
   httpGet:
     path: /metrics
     port: metrics
-  # initialDelaySeconds: 0
-  # periodSeconds: 10
-  # timeoutSeconds: 1
-  # successThreshold: 1
-  # failureThreshold: 3
+    # initialDelaySeconds: 0
+    # periodSeconds: 10
+    # timeoutSeconds: 1
+    # successThreshold: 1
+    # failureThreshold: 3
 
 # Configure the readinessProbe
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -72,18 +73,18 @@ readinessProbe:
   httpGet:
     path: /metrics
     port: metrics
-  # initialDelaySeconds: 0
-  # periodSeconds: 10
-  # timeoutSeconds: 1
-  # successThreshold: 1
-  # failureThreshold: 3
+    # initialDelaySeconds: 0
+    # periodSeconds: 10
+    # timeoutSeconds: 1
+    # successThreshold: 1
+    # failureThreshold: 3
 
 resources: {}
-  # requests:
-  #   cpu: 10m
-  #   memory: 128Mi
-  # limits:
-  #   memory: 128Mi
+# requests:
+#   cpu: 10m
+#   memory: 128Mi
+# limits:
+#   memory: 128Mi
 
 ## only available if kind is Deployment
 autoscaling:
@@ -94,13 +95,13 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
   ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
   customRules: []
-    # - type: Pods
-    #   pods:
-    #     metric:
-    #       name: packets-per-second
-    #     target:
-    #       type: AverageValue
-    #       averageValue: 1k
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: packets-per-second
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 1k
   ## see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
   # behavior:
   #   scaleDown:
@@ -162,12 +163,12 @@ updateStrategy: {}
 
 ## Additional environment variables to set for fluentd pods
 env: []
-  # - name: "FLUENTD_CONF"
-  #   value: "../../../etc/fluent/fluent.conf"
-  # - name: FLUENT_ELASTICSEARCH_HOST
-  #   value: "elasticsearch-master"
-  # - name: FLUENT_ELASTICSEARCH_PORT
-  #   value: "9200"
+# - name: "FLUENTD_CONF"
+#   value: "../../../etc/fluent/fluent.conf"
+# - name: FLUENT_ELASTICSEARCH_HOST
+#   value: "elasticsearch-master"
+# - name: FLUENT_ELASTICSEARCH_PORT
+#   value: "9200"
 
 envFrom: []
 


### PR DESCRIPTION
Added a variable in `values.yaml` (`outputType`) that corresponds to the type of output plugin you're using and changes to the _pod.tpl `$defaultTag` to pull the correct image since left alone will pull the wrong image.

changes to `_pod.tpl`:

```yaml
{{- define "fluentd.pod" -}}
{{- $defaultTag := printf "%s-debian-%s-1.0" (.Chart.AppVersion) (.Values.outputType) -}}
{....}
```

changes to `values.yaml`:

```yaml
# azureblob, cloudwatch, elasticsearch7, elasticsearch8, gcs, graylog , kafka, kafka2, kinesis, opensearch     
outputType: elasticsearch7
```

changes to `Chart.yaml` (just updated the AppVersion since it was used by default to pull version of fluentd):

```yaml
appVersion: v1.16.2
```

Scenario:
i'm testing `fluentd` and `fluentbit` with `opensearch` without the changes the pod pulls a fluentd-daemonset elasticsearch image that doesn't have opensearch plugin inside it to run my output config.