### PR TITLE
feat: add support for StatefulSet in fluent-bit chart

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.34.2
+version: 0.35.0
 appVersion: 2.1.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Added support for using an existing SecurityContextConstraints for OpenShift."
+      description: "Added support for deploying fluent-bit as a StatefulSet"

--- a/charts/fluent-bit/templates/statefulset.yaml
+++ b/charts/fluent-bit/templates/statefulset.yaml
@@ -1,0 +1,55 @@
+{{- if eq .Values.kind "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or (not .Values.hotReload.enabled) .Values.podAnnotations }}
+      annotations:
+      {{- if not .Values.hotReload.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.luaScripts }}
+        checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+    spec:
+      {{- include "fluent-bit.pod" . | nindent 6 }}
+  {{- with .Values.statefulSetVolumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -1,9 +1,9 @@
 # Default values for fluent-bit.
 
-# kind -- DaemonSet or Deployment
+# kind -- DaemonSet, Deployment, or StatefulSet
 kind: DaemonSet
 
-# replicaCount -- Only applicable if kind=Deployment
+# replicaCount -- Only applicable if kind=Deployment or StatefulSet
 replicaCount: 1
 
 image:
@@ -461,6 +461,17 @@ daemonSetVolumeMounts:
     mountPath: /etc/machine-id
     readOnly: true
 
+statefulSetVolumeClaimTemplates: []
+# - apiVersion: v1
+#   kind: PersistentVolumeClaim
+#   metadata:
+#     name: volume-name
+#   spec:
+#     accessModes:
+#     - ReadWriteOnce
+#     resources:
+#       requests:
+#         storage: 16Gi
 command: []
 
 args:


### PR DESCRIPTION
This adds the initial support to deploy fluent-bit chart as a StatefulSet, which is helpful when using the Filesystem storage and using fluent-bit as a set of collectors, which allows when scaling fluent-bit to dynamically create the volumes where the data is stored, and also when it recovers so it can keep reading from the same volume in case of a crash. 