### PR TITLE
[Fluent Bit] Fix Openshift SCC name template

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.35.0
+version: 0.35.1
 appVersion: 2.1.7
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -24,3 +24,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: "Updated Fluent Bit image to v2.1.7."
+    - kind: fixed
+      description: "Fluent Bit SCC name template"
+      links:
+        - name: GitHub Issue
+          url: https://github.com/fluent/helm-charts/issues/399

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -133,6 +133,6 @@ Create the name of OpenShift SecurityContextConstraints to use
 {{- if not .Values.openShift.securityContextConstraints.create -}}
 {{- printf "%s" .Values.openShift.securityContextConstraints.existingName -}}
 {{- else -}}
-{{- printf "%s" default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name -}}
+{{- printf "%s" (default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name) -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This PR should fix https://github.com/fluent/helm-charts/issues/399.

It was tested on OKD 4.11 (Openshift upstream) cluster.