### PR TITLE
feat(fluent-bit) Set command binary for fluent-bit

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.35.1
+version: 0.36.0
 appVersion: 2.1.7
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,10 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated Fluent Bit image to v2.1.7."
-    - kind: fixed
-      description: "Fluent Bit SCC name template"
-      links:
-        - name: GitHub Issue
-          url: https://github.com/fluent/helm-charts/issues/399
+    - kind: added
+      description: "Set fluent-bit binary as command"

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -461,7 +461,8 @@ daemonSetVolumeMounts:
     mountPath: /etc/machine-id
     readOnly: true
 
-command: []
+command:
+  - /fluent-bit/bin/fluent-bit
 
 args:
   - --workdir=/fluent-bit/etc


### PR DESCRIPTION
After this PR(#384) my fluent-bit deployment stopped working well as reported on this issue(https://github.com/fluent/helm-charts/issues/392).
The problem happens only if I use the debug image in my Kubernetes cluster to be able to access to the shell if needed.

To remain the same behaviour that we were having before this PR, I suggest to set the fluent-bit binary as a command.
This won´t cause any problem to the main docker image, it only adds compatibility with the image with suffix **-debug**. 

You can check the differentes between both docker images in this [link](https://github.com/fluent/fluent-bit/blob/master/dockerfiles/Dockerfile), where you can see that the production image has the entrypoint but the debug no.

Another option is to add the binary to the first line of the args, but in my opinion that´s not the best fix because that´s not the place for the binary.