### PR TITLE
[fluent-bit] Enable cluster role events access by values

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.37.0
+version: 0.37.1
 appVersion: 2.1.8
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit OCI image to v2.1.8."
+      description: "Add events permission to ClusteRole"

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Add events permission to ClusteRole"
+    - kind: added
+      description: "Added events permission to ClusteRole"

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -15,6 +15,9 @@ rules:
       - nodes
       - nodes/proxy
       {{- end }}
+      {{- if .Values.rbac.eventsAccess }}
+      - events
+      {{- end }}
     verbs:
       - get
       - list

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -35,6 +35,7 @@ serviceAccount:
 rbac:
   create: true
   nodeAccess: false
+  eventsAccess: false
 
 # Configure podsecuritypolicy
 # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
Hey,
We recently deployed the latest chart (0.37.0) and enabled kubernetes_events according to [this doc](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes-events#simple-configuration-file)

However the ClusterRole that is created by the chart is missing the events resources access and thus fluent-bit starts throwing errors and no events are collected.

Simply adding `events` to the ClusterRole resource resolves the issue.

I placed it behind a flag as events input is not used by default and that might add unnecessary load on fluent-bit and the services that consume it, let me know if you would like to change the logic or values structure here.