### PR TITLE
feat(fluent-operator): added priorityClassName mapping to fluentd

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.3.0
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg
 home: https://www.fluentd.org/

--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -24,5 +24,6 @@ spec:
   {{- if .Values.fluentd.logLevel }}
   logLevel: {{ .Values.fluentd.logLevel }}
   {{- end }}
+  priorityClassName: {{ .Values.fluentd.priorityClassName }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -243,6 +243,7 @@ fluentd:
       memory: 128Mi
   schedulerName: ""
   logLevel: ""
+  priorityClassName: ""
   # Configure the output plugin parameter in Fluentd.
   # Fluentd is disabled by default, if you enable it make sure to also set up an output to use.
   output:


### PR DESCRIPTION
Unfortunately, the fluentd section does not currently support setting the priorityClassName field, which may be required in some environments. To solve this problem, I made this small change.