### PR TITLE
fix(fluent-operator): fluentd watchedNamespaces mapping

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.3.0
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg
 home: https://www.fluentd.org/

--- a/charts/fluent-operator/templates/fluentd-clusterfluentdconfig.yaml
+++ b/charts/fluent-operator/templates/fluentd-clusterfluentdconfig.yaml
@@ -8,9 +8,7 @@ metadata:
     config.fluentd.fluent.io/enabled: "true"
 spec:
   watchedNamespaces:
-  {{- range .Values.fluentd.watchedNamespaces }}
-  - {{ . }}
-  {{- end }}
+    {{- toYaml .Values.fluentd.watchedNamespaces | nindent 4 }}
   clusterFilterSelector:
     matchLabels:
       filter.fluentd.fluent.io/enabled: "true"


### PR DESCRIPTION
To be able to set an empty array for watchedNamespaces, we need to change the way properties are added. Currently, if we set an empty array as a property, we get the following error message:  `ClusterFluentdConfig.fluentd.fluent.io "fluentd-config" is invalid: spec.watchedNamespaces: Invalid value: "null": spec.watchedNamespaces in body must be of type array: "null"`. The reason for this error message is that `[]` does not count as a value with an index, so the CR key is set to `null`, which is not a valid value.