### PR TITLE
[fluentd] Fix autoscaling/v2beta2 deprecation

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: v1.16.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/hpa.yaml
+++ b/charts/fluentd/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and  ( eq  .Values.kind "Deployment" )  .Values.autoscaling.enabled  }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fluentd.fullname" . }}


### PR DESCRIPTION
Starting from kubernetes v1.26 autoscaling/v2beta2 is deprecated https://kubernetes.io/docs/reference/using-api/deprecation-guide/

Closes: https://github.com/fluent/helm-charts/issues/416