### PR TITLE
docs(contributing): added note to contributing guide related to fluent-operator contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,10 @@ See `git help commit`:
 2. Remember to sign off your commits as described above
 3. Submit a pull request
 
-***NOTE***: In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
+***NOTES***: 
+
+* In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
+* In order to make changes to the fluent-operator Helm chart, please submit changes to the [fluent/fluent-operator Helm chart](https://github.com/fluent/fluent-operator/tree/master/charts/fluent-operator). The chart in this repository will be synced synced to the release chart in fluent/fluent-operator whenever there is a new release for fluent-operator.
 
 ### Technical Requirements
 

--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 2.3.0
+version: 2.4.0
 appVersion: 2.3.0
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg
 home: https://www.fluentd.org/

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -71,7 +71,7 @@ spec:
   {{- end }}
   {{- if .Values.fluentbit.serviceAccountAnnotations }}
   serviceAccountAnnotations:
-{{ toYaml .Values.fluentbit.labels | indent 4 }}
+{{ toYaml .Values.fluentbit.serviceAccountAnnotations | indent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -69,5 +69,9 @@ spec:
   labels:
 {{ toYaml .Values.fluentbit.labels | indent 4 }}
   {{- end }}
+  {{- if .Values.fluentbit.serviceAccountAnnotations }}
+  serviceAccountAnnotations:
+{{ toYaml .Values.fluentbit.labels | indent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -81,6 +81,9 @@ fluentbit:
   # Specify additional custom labels for fluentbit-pods
   labels: {}
 
+  # Specify additional custom annotations for fluentbit-serviceaccount
+  serviceAccountAnnotations: {}
+
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##


### PR DESCRIPTION
Added a small note to the contributing guide to clarify how contributions to the fluent-operator Helm chart should be made (i.e. in fluent/fluent-operator first).

Please let me know if you'd like me to make any changes - would be happy to do so!