### PR TITLE
feat: add note to contributing guide regarding contributions to fluent-operator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,10 @@ See `git help commit`:
 2. Remember to sign off your commits as described above
 3. Submit a pull request
 
-***NOTE***: In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
+***NOTES***: 
+
+* In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
+* In order to make changes to the fluent-operator Helm chart, please submit changes to the [fluent/fluent-operator Helm chart](https://github.com/fluent/fluent-operator/tree/master/charts/fluent-operator). The chart in this repository will be synced synced to the release chart in fluent/fluent-operator whenever there is a new release for fluent-operator.
 
 ### Technical Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ See `git help commit`:
 ***NOTES***: 
 
 * In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
-* In order to make changes to the fluent-operator Helm chart, please submit changes to the [fluent/fluent-operator Helm chart](https://github.com/fluent/fluent-operator/tree/master/charts/fluent-operator). The chart in this repository will be synced synced to the release chart in fluent/fluent-operator whenever there is a new release for fluent-operator.
+* In order to make changes to the fluent-operator Helm chart, please submit changes to the [fluent/fluent-operator Helm chart](https://github.com/fluent/fluent-operator/tree/master/charts/fluent-operator). The chart in this repository will be synced to the release chart in fluent/fluent-operator whenever there is a new release for fluent-operator.
 
 ### Technical Requirements
 


### PR DESCRIPTION
Added a small note to the contributing guide to clarify how contributions to the fluent-operator Helm chart should be made (i.e. in fluent/fluent-operator first).

Please let me know if you'd like me to make any changes - would be happy to do so!