### PR TITLE
feat(fluentd): Allow service to be optional for the daemonset deployment; enabled by default

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: v1.16.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/service.yaml
+++ b/charts/fluentd/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.kind "DaemonSet") .Values.service.enabled -}}
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/fluentd/templates/service.yaml
+++ b/charts/fluentd/templates/service.yaml
@@ -1,4 +1,4 @@
-
+{{- if and (eq .Values.kind "DaemonSet") .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,3 +32,4 @@ spec:
   {{- end }}
   selector:
     {{- include "fluentd.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -200,6 +200,7 @@ persistence:
 ## Fluentd service
 ##
 service:
+  enabled: true
   type: "ClusterIP"
   annotations: {}
   # loadBalancerIP:


### PR DESCRIPTION
Allows users to deploy fluentd without any service, in case they want to only use log forwarding and don't care about serving metrics