### PR TITLE
[fluent-bit] Fix Grafana dashboard error

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.39.0
+version: 0.39.1
 appVersion: 2.1.10
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit OCI image to v2.1.10."
+      description: "Replaced statically configured datasource with placeholder in grafana dashboard json"

--- a/charts/fluent-bit/dashboards/fluent-bit.json
+++ b/charts/fluent-bit/dashboards/fluent-bit.json
@@ -5,7 +5,7 @@
         "builtIn": 1,
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "hide": true,
@@ -28,7 +28,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$DS_PROMETHEUS"
       },
       "gridPos": {
         "h": 1,
@@ -42,7 +42,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$DS_PROMETHEUS"
           },
           "refId": "A"
         }
@@ -144,7 +144,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$DS_PROMETHEUS"
       },
       "gridPos": {
         "h": 1,
@@ -158,7 +158,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$DS_PROMETHEUS"
           },
           "refId": "A"
         }
@@ -1171,7 +1171,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$DS_PROMETHEUS"
       },
       "gridPos": {
         "h": 1,
@@ -1185,7 +1185,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$DS_PROMETHEUS"
           },
           "refId": "A"
         }
@@ -1321,7 +1321,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
@@ -1420,7 +1420,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\",pod=~\"$pod\",container=\"fluent-bit\"}) by (pod)",
@@ -1432,7 +1432,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "avg(kube_pod_container_resource_requests{job=\"kube-state-metrics\",namespace=\"$namespace\",pod=~\"$pod\",container=\"fluent-bit\",resource=\"cpu\"})",


### PR DESCRIPTION
Replace the statically configured prometheus datasource uid with the placeholder to fix the following Grafana error:

![Pasted image 20231027210631](https://github.com/fluent/helm-charts/assets/91630231/778cf26e-217a-416c-b006-5098a78e8450)
