### PR TITLE
Correct fluentd helm tests

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd
 description: A Helm chart for Kubernetes
 # type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: v1.16.2
 icon: https://www.fluentd.org/images/miscellany/fluentd-logo_2x.png
 home: https://www.fluentd.org/

--- a/charts/fluentd/templates/tests/test-connection.yaml
+++ b/charts/fluentd/templates/tests/test-connection.yaml
@@ -17,7 +17,13 @@ spec:
   containers:
     - name: wget
       image: busybox
-      command: ['wget']
-      args: ['{{ include "fluentd.fullname" . }}:24231/metrics']
+      command:
+        - sh
+        - -c
+        - |
+          set -e
+          # Give fluentd some time to start up
+          while :; do nc -vz {{ include "fluentd.fullname" . }}:24231 && break; sleep 1; done
+          wget '{{ include "fluentd.fullname" . }}:24231/metrics'
   restartPolicy: Never
 {{ end }}

--- a/charts/fluentd/templates/tests/test-connection.yaml
+++ b/charts/fluentd/templates/tests/test-connection.yaml
@@ -1,3 +1,10 @@
+{{/*
+Target the very simple case where
+fluentd is deployed with the default values
+If the fluentd config is overriden and the metrics server removed
+this will fail.
+*/}}
+{{ if empty .Values.service.ports }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -11,5 +18,6 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "fluentd.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "fluentd.fullname" . }}:24231/metrics']
   restartPolicy: Never
+{{ end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -318,6 +318,14 @@ fileConfigs:
       emit_unmatched_lines true
     </source>
 
+    # expose metrics in prometheus format
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port 24231
+      metrics_path /metrics
+    </source>
+
   02_filters.conf: |-
     <label @KUBERNETES>
       <match kubernetes.var.log.containers.fluentd**>

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -375,6 +375,8 @@ fileConfigs:
         path ""
         user elastic
         password changeme
+        # Don't wait for elastic to start up.
+        verify_es_version_at_startup false
       </match>
     </label>
 


### PR DESCRIPTION
Added a few tweaks to make the current default values a bit more complete from a working out of the box perspective and to enable the existing test to pass.
Related to #440 