### PR TITLE
feat(fluent-bit): ServiceMonitor path values

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.40.1
+version: 0.41.0
 appVersion: 2.2.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit OCI image to v2.2.0."
+      description: "Updated the ServiceMonitor path to use the v2 metrics"

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.40.0
+version: 0.40.1
 appVersion: 2.2.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
   jobLabel: app.kubernetes.io/instance
   endpoints:
     - port: http
-      path: /api/v1/metrics/prometheus
+      path: {{ default "/api/v1/metrics/prometheus" .Values.serviceMonitor.path }}
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
   jobLabel: app.kubernetes.io/instance
   endpoints:
     - port: http
-      path: {{ default "/api/v1/metrics/prometheus" .Values.serviceMonitor.path }}
+      path: {{ default "/api/v2/metrics/prometheus" .Values.serviceMonitor.path }}
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Sébastien Larivière <sebastien.lariviere@goto.com>

Keeps the path to `v1` by default, but allows it to be updated to `v2` if needed.