### PR TITLE
set Suppress_Type_Name to On for ElasticSearch output

### DIFF
--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -396,6 +396,7 @@ config:
         Host elasticsearch-master
         Logstash_Format On
         Retry_Limit False
+        Suppress_Type_Name On
 
     [OUTPUT]
         Name es
@@ -404,6 +405,7 @@ config:
         Logstash_Format On
         Logstash_Prefix node
         Retry_Limit False
+        Suppress_Type_Name On
 
   ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers
   ## This configuration is deprecated, please use `extraFiles` instead.


### PR DESCRIPTION
For ElasticSearch output, the default value of Suppress_Type_Name is Off:
https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch

That means, that out of the box FluentBit can only work with ElasticSearch version 6.x.
If output sent to ElasticSearch 8.x, the output will fail.

Support for Elastic 6.x was ended [~2 years ago](https://endoflife.date/elasticsearch).

Changing the value of Suppress_Type_Name to On will enable it to work with version 8.x out of the box.