### PR TITLE
feat(fluent-bit): Support tpl in extraContainers

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.46.3
+version: 0.46.4
 appVersion: 3.0.3
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -24,5 +24,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "Support setting extraContainers to a string value to enable full templating."
-    - kind: removed
-      description: "Don't template extraContainers when set to an array."

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.46.2
+version: 0.46.3
 appVersion: 3.0.2
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,5 +22,7 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated _Fluent Bit_ OCI image to [v3.0.2](https://github.com/fluent/fluent-bit/releases/tag/v3.0.2)."
+    - kind: added
+      description: "Support setting extraContainers to a string value to enable full templating."
+    - kind: removed
+      description: "Don't template extraContainers when set to an array."

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -119,7 +119,11 @@ containers:
     {{- end }}
 {{- end }}
 {{- if .Values.extraContainers }}
-  {{- toYaml .Values.extraContainers | nindent 2 }}
+  {{- if kindIs "string" .Values.extraContainers }}
+    {{- tpl .Values.extraContainers $ | nindent 2 }}
+  {{- else }}
+    {{-  toYaml .Values.extraContainers | nindent 2 }}
+  {{- end -}}
 {{- end }}
 volumes:
   - name: config

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -314,10 +314,20 @@ envWithTpl: []
 
 envFrom: []
 
+# This supports either a structured array or a templatable string
 extraContainers: []
+
+# Array mode
+# extraContainers:
 #   - name: do-something
 #     image: busybox
 #     command: ['do', 'something']
+
+# String mode
+# extraContainers: |-
+#   - name: do-something
+#     image: bitnami/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}
+#     command: ['kubectl', 'version']
 
 flush: 1
 


### PR DESCRIPTION
The same as https://github.com/fluent/helm-charts/pull/163, support tpl in extraContainers.

- Support templating when value is a string
- No templating when value is an array due to inconsistent behaviour