### PR TITLE
Add posibility to assign ExternalIPs  to fluentbit's Service

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.46.4
+version: 0.46.5
 appVersion: 3.0.3
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Support setting extraContainers to a string value to enable full templating."
+      description: "Support setting Service's externalIPs."

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   {{- if and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
   {{- if (eq .Values.kind "DaemonSet") }}
   {{- with .Values.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ . }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -101,6 +101,10 @@ service:
 #   prometheus.io/path: "/api/v1/metrics/prometheus"
 #   prometheus.io/port: "2020"
 #   prometheus.io/scrape: "true"
+  externalIPs: []
+  # externalIPs:
+  #  - 2.2.2.2
+
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
This PR extends the fluentbit Service with ExternalIPs, if any is defined.
I've followed same pattern many [other](https://github.com/search?q=externalIPs%3A+%7B%7B-+toYaml+.Values.service.externalIPs+%7C+nindent+4+%7D%7D&type=code) charts are already using.
Small update but might be helpful to others as well.