### PR TITLE
Create unqiue uid for grafana fluent-bit dashboard

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.46.5
+version: 0.46.6
 appVersion: 3.0.3
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Support setting Service's externalIPs."
+      description: "Create unqiue uid for grafana fluent-bit dashboard."

--- a/charts/fluent-bit/dashboards/fluent-bit.json
+++ b/charts/fluent-bit/dashboards/fluent-bit.json
@@ -1559,7 +1559,7 @@
   },
   "timezone": "",
   "title": "{{ include "fluent-bit.fullname" . }}",
-  "uid": "d557c8f6-cac1-445f-8ade-4c351a9076b1",
+  "uid": "{{ include "fluent-bit.dashboard.uid" . }}",
   "version": 7,
   "weekStart": ""
 }

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -136,3 +136,9 @@ Create the name of OpenShift SecurityContextConstraints to use
 {{- printf "%s" (default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name) -}}
 {{- end -}}
 {{- end -}}
+{{/*
+Create the uid for grafana fluent-bit dashboard
+*/}}
+{{- define "fluent-bit.dashboard.uid" -}}
+{{- sha256sum (printf "%s/%s" .Release.Namespace .Release.Name) }}
+{{- end -}}


### PR DESCRIPTION
Conflict in UIDs of Grafana dashboard when running multiple Fluent Bit Helm Release.

Fixes #499 
