### PR TITLE
Patch Fluent-Bit CVE-2024-4323

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Create unqiue uid for grafana fluent-bit dashboard."
+    - kind: changed
+      description: "Update _Fluent Bit_ OCI image to [v3.0.4](https://github.com/fluent/fluent-bit/releases/tag/v3.0.4) to patch CVE-2024-4323."

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.46.6
-appVersion: 3.0.3
+version: 0.46.7
+appVersion: 3.0.4
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:


### PR DESCRIPTION
Upgrade Fluent-bit to v3.0.4 to patch [CVE-2024-4323](https://nvd.nist.gov/vuln/detail/CVE-2024-4323)
Since the release is ready https://github.com/fluent/fluent-bit/releases with the image patched, this PR serves only the purpose of bumping the appVersion.

Additional info:
- https://vulners.com/cve/CVE-2024-4323
- https://www.tenable.com/blog/linguistic-lumberjack-attacking-cloud-services-via-logging-endpoints-fluent-bit-cve-2024-4323