### PR TITLE
limits the length of the grafana dashboard uid to 40 to prevent grafa…

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.46.9
+version: 0.46.10
 appVersion: 3.0.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update _Fluent Bit_ OCI image to [v3.0.6](https://github.com/fluent/fluent-bit/releases/tag/v3.0.6)"
+      description: "Dashboard: remove dashboard.uid function and set the uid to null"

--- a/charts/fluent-bit/dashboards/fluent-bit.json
+++ b/charts/fluent-bit/dashboards/fluent-bit.json
@@ -1559,7 +1559,7 @@
   },
   "timezone": "",
   "title": "{{ include "fluent-bit.fullname" . }}",
-  "uid": "{{ include "fluent-bit.dashboard.uid" . }}",
+  "uid": null,
   "version": 7,
   "weekStart": ""
 }

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -136,9 +136,3 @@ Create the name of OpenShift SecurityContextConstraints to use
 {{- printf "%s" (default (include "fluent-bit.fullname" .) .Values.openShift.securityContextConstraints.name) -}}
 {{- end -}}
 {{- end -}}
-{{/*
-Create the uid for grafana fluent-bit dashboard
-*/}}
-{{- define "fluent-bit.dashboard.uid" -}}
-{{- sha256sum (printf "%s/%s" .Release.Namespace .Release.Name) }}
-{{- end -}}


### PR DESCRIPTION
…na import error

When trying to import the dashboard json the grafana container throws `logger=provisioning.dashboard type=file name=file t=2024-05-23T06:54:30.144967684Z level=error msg="failed to save dashboard" file=/tmp/dashboards/fluentbit-fluent-bit-fluent-bit.json error="uid too long, max 40 characters"`

With this fix the length of the uid is trunctated to 40 chars.