### PR TITLE
feat(fluent-bit): give fluent-bit access to kubelet metrics

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.47.3
+version: 0.47.4
 appVersion: 3.1.3
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit OCI image to v3.1.3."
+      description: "Give fluent-bit role access to kubelet metrics."

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - pods
       {{- if .Values.rbac.nodeAccess }}
       - nodes
+      - nodes/metrics
       - nodes/proxy
       {{- end }}
       {{- if .Values.rbac.eventsAccess }}


### PR DESCRIPTION
this change allows fluent-bit to scrape metrics from Kubelet /metrics and /metrcis/cadvisor endpoints 