### PR TITLE
Add option to configure seLinux and runAs policies

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.48.1
+version: 0.48.2
 appVersion: 3.2.1
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated configmap-reload image to v0.14.0"
+      description: "Add option to configure seLinux and runAs policies"

--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -20,12 +20,15 @@ spec:
   hostNetwork: {{ .Values.hostNetwork }}
   hostIPC: false
   hostPID: false
+{{- with .Values.podSecurityPolicy.runAsUser }}
   runAsUser:
-    # TODO: Require the container to run without root privileges.
-    rule: 'RunAsAny'
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.podSecurityPolicy.seLinux }}
   seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -24,10 +24,14 @@ forbiddenSysctls:
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
   - MKNOD
+{{- with .Values.openShift.securityContextConstraints.runAsUser }}
 runAsUser:
-  type: RunAsAny
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.openShift.securityContextConstraints.seLinuxContext }}
 seLinuxContext:
-  type: MustRunAs
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 supplementalGroups:
   type: RunAsAny
 volumes:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -45,6 +45,11 @@ rbac:
 podSecurityPolicy:
   create: false
   annotations: {}
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: RunAsAny
 
 # OpenShift-specific configuration
 openShift:
@@ -54,6 +59,10 @@ openShift:
     create: true
     name: ""
     annotations: {}
+    runAsUser:
+      type: RunAsAny
+    seLinuxContext:
+      type: MustRunAs
     # Use existing SCC in cluster, rather then create new one
     existingName: ""
 


### PR DESCRIPTION
EDIT: after discussions, we decided to make seLinux and runAs policies configurable instead of changing the default.

When creating a securityContextContraint for Openshift, the helm chart currently set the selinux strategy to `MustRunAs`, but this might lead to permission errors if you are using selinux in the node and you want to mount an host folder with an HostPath.

I think there is no reason for disallowing selinux context to be changed for the fluentbit deployment. Also, this is the same behavior used by red hat for their cluster logging operator that deploys fluentd.
https://github.com/openshift/cluster-logging-operator/blob/master/internal/auth/securitycontextconstraint.go#L46