### PR TITLE
Copy extraContainers from fluent-bit to fluentd chart

### DIFF
--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -87,6 +87,13 @@ containers:
     - mountPath: /var/log/fluent
       name: {{ include "fluentd.fullname" . }}-buffer
     {{- end }}
+{{- if .Values.extraContainers }}
+  {{- if kindIs "string" .Values.extraContainers }}
+    {{- tpl .Values.extraContainers $ | nindent 2 }}
+  {{- else }}
+    {{-  toYaml .Values.extraContainers | nindent 2 }}
+  {{- end -}}
+{{- end }}
 volumes:
 - name: etcfluentd-main
   configMap:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -174,6 +174,21 @@ envFrom: []
 
 initContainers: []
 
+# This supports either a structured array or a templatable string
+extraContainers: []
+
+# Array mode
+# extraContainers:
+#   - name: do-something
+#     image: busybox
+#     command: ['do', 'something']
+
+# String mode
+# extraContainers: |-
+#   - name: do-something
+#     image: bitnami/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}
+#     command: ['kubectl', 'version']
+
 ## Name of the configMap containing a custom fluentd.conf configuration file to use instead of the default.
 # mainConfigMapNameOverride: ""
 


### PR DESCRIPTION
Copy both the templating for `extraContainers` and the examples in the values file from the fluent-bit chart.

This allows the fluentd chart to define sidecar containers as well.

Example use case:
```yaml
volumes:
  - name: tls
    secret:
      secretName: fluentd-tls

volumeMounts:
  - name: tls
    mountPath: "/fluentd/certs"

extraContainers:
  - name: cert-reloader
    image: alpine:3.20
    command: ["/bin/sh"]
    args:
    - -c
    - |
      apk add --no-cache curl inotify-tools
      while true; do
        inotifywait -e delete_self /fluentd/certs/tls.crt
        echo "certificate changed at $(date)"
        curl -s -w "\n" http://127.0.0.1:24444/api/config.gracefulReload
        echo "certificates reloaded"
        sleep 1
      done
    volumeMounts:
    - name: tls
      mountPath: /fluentd/certs/
```
to trigger a reload of TLS certificates from a sidecar container, for use with the `forward` input plugin.