### PR TITLE
feat(fluent-bit): Updated image to v3.1.10

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.47.10
-appVersion: 3.1.9
+version: 0.47.11
+appVersion: 3.1.10
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit OCI image to v3.1.9"
+      description: "Updated Fluent Bit OCI image to v3.1.10"

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -12,7 +12,7 @@ image:
   # Set to "-" to not use the default value
   tag:
   digest:
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 testFramework:
   enabled: true


### PR DESCRIPTION
The following PR updates the Fluent Bit image to the latest version available: v3.1.10:

- https://fluentbit.io/announcements/v3.1.10/

In addition, I am reverting the change that was done in the PullPolicy for the main image from 'IfNotPresent' to 'Always'. As you know, we don't do user-telemetry in Fluent Bit, our only indicator of adoption is the number of deployments/downloads from the containers registry. Users can always tweak this value, so I am just changing the default as the one we had before.