### PR TITLE
feat(fluent-bit): Updated image to 3.2.1

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.47.11
-appVersion: 3.1.10
+version: 0.48.0
+appVersion: 3.2.1
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:
@@ -23,4 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Updated Fluent Bit OCI image to v3.1.10"
+      description: "Updated Fluent Bit OCI image to v3.2.1."

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -12,7 +12,7 @@ image:
   # Set to "-" to not use the default value
   tag:
   digest:
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 testFramework:
   enabled: true
@@ -98,13 +98,12 @@ service:
   # nodePort: 30020
   # clusterIP: 172.16.10.1
   annotations: {}
-#   prometheus.io/path: "/api/v1/metrics/prometheus"
-#   prometheus.io/port: "2020"
-#   prometheus.io/scrape: "true"
+  #   prometheus.io/path: "/api/v1/metrics/prometheus"
+  #   prometheus.io/port: "2020"
+  #   prometheus.io/scrape: "true"
   externalIPs: []
   # externalIPs:
   #  - 2.2.2.2
-
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
This PR updates the Fluent Bit version to [3.2.1](https://github.com/fluent/fluent-bit/releases/tag/v3.2.1). It also reverts the change to image pull policy made in #565 which serves no purpose, besides inflating the Docker pulls, given the image reference is immutable; the major downside of this is that it can cause Docker Hub rate limits to quickly be hit as every time a container starts on a node the image index will be pulled even if the image already exists. For reference the reason the chart originally had a pull policy of `Always` was that it used a mutable tag (such as `v2`) that was allowed to update on each container start.

CC @patrick-stephens