### PR TITLE
[fluent-bit] optional podVersionLabel feature flag to include app.kubernetes.io/version applied to all pods

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
 version: 0.48.4
-appVersion: 3.2.2
+appVersion: 3.2.4
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
 sources:

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.48.3
+version: 0.48.4
 appVersion: 3.2.2
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.48.4
+version: 0.48.5
 appVersion: 3.2.4
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -52,9 +52,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Pod labels
+Verbose Pod labels
 */}}
-{{- define "fluent-bit.podLabels" -}}
+{{- define "fluent-bit.verbosePodLabels" -}}
 {{ include "fluent-bit.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -52,6 +52,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+Pod labels
+*/}}
+{{- define "fluent-bit.podLabels" -}}
+{{ include "fluent-bit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "fluent-bit.serviceAccountName" -}}

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Verbose Pod labels
 */}}
-{{- define "fluent-bit.verbosePodLabels" -}}
+{{- define "fluent-bit.podVersionLabel" -}}
 {{ include "fluent-bit.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -27,7 +27,11 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "fluent-bit.podLabels" . | nindent 8 }}
+        {{- if .Values.verbosePodLabels.enabled }}
+          {{- include "fluent-bit.verbosePodLabels" . | nindent 8 }}
+        {{- else }}
+          {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -27,11 +27,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- if .Values.verbosePodLabels.enabled }}
-          {{- include "fluent-bit.verbosePodLabels" . | nindent 8 }}
-        {{- else }}
-          {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
-        {{- end }}
+        {{- include (ternary "fluent-bit.verbosePodLabels" "fluent-bit.selectorLabels" .Values.verbosePodLabels)  . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include (ternary "fluent-bit.verbosePodLabels" "fluent-bit.selectorLabels" .Values.verbosePodLabels)  . | nindent 8 }}
+        {{- include (ternary "fluent-bit.podVersionLabel" "fluent-bit.selectorLabels" .Values.podVersionLabel)  . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
+        {{- include "fluent-bit.podLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
+        {{- include "fluent-bit.podLabels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -30,11 +30,7 @@ spec:
   template:
     metadata:
       labels:
-      {{- if .Values.verbosePodLabels.enabled }}
-        {{- include "fluent-bit.verbosePodLabels" . | nindent 8 }}
-      {{- else }}
-        {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
-      {{- end }}
+      {{- include (ternary "fluent-bit.verbosePodLabels" "fluent-bit.selectorLabels" .Values.verbosePodLabels)  . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-      {{- include (ternary "fluent-bit.verbosePodLabels" "fluent-bit.selectorLabels" .Values.verbosePodLabels)  . | nindent 8 }}
+      {{- include (ternary "fluent-bit.podVersionLabel" "fluent-bit.selectorLabels" .Values.podVersionLabel)  . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -30,7 +30,11 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "fluent-bit.podLabels" . | nindent 8 }}
+      {{- if .Values.verbosePodLabels.enabled }}
+        {{- include "fluent-bit.verbosePodLabels" . | nindent 8 }}
+      {{- else }}
+        {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -302,6 +302,10 @@ podAnnotations: {}
 
 podLabels: {}
 
+# adds app.kubernetes.io/version label to pods for istio required labels
+verbosePodLabels:
+  enabled: false
+
 ## How long (in seconds) a pods needs to be stable before progressing the deployment
 ##
 minReadySeconds:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -303,7 +303,7 @@ podAnnotations: {}
 podLabels: {}
 
 # adds app.kubernetes.io/version label to pods for istio required labels
-verbosePodLabels: false
+podVersionLabel: false
 
 ## How long (in seconds) a pods needs to be stable before progressing the deployment
 ##

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -303,8 +303,7 @@ podAnnotations: {}
 podLabels: {}
 
 # adds app.kubernetes.io/version label to pods for istio required labels
-verbosePodLabels:
-  enabled: false
+verbosePodLabels: false
 
 ## How long (in seconds) a pods needs to be stable before progressing the deployment
 ##


### PR DESCRIPTION
What this PR does / why we need it:

- It adds common labels to metadata labels in the pod spec. The main reasoning is to persist the app.kubernetes.io/version and app.kubernetes.io/name labels to the pod for standardization. Per docs, (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) "In order to take full advantage of using these labels, they should be applied on every resource object.".

- Improves traceability throughout the application. Ex. via Istio/Kiali dashboard.