### PR TITLE
fix(fluent-bit): append .Values.labels to all resources

### DIFF
--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "fluent-bit.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{- toYaml .Values.labels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/fluent-bit/templates/psp.yaml
+++ b/charts/fluent-bit/templates/psp.yaml
@@ -3,6 +3,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
 {{- if .Values.podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml .Values.podSecurityPolicy.annotations | nindent 4 }}


### PR DESCRIPTION
Currently the `labels` value is added inconsistently to a few resources (`DaemonSet`, `Deployment`) but not any of the other resource types. This is annoying if you want to append/enforce a label on all of the resources for this chart, not just the workload resources.

This PR moves the labels to the `fluent-bit.labels` named template so they will be added to all resources in the chart. Additionally, it adds the include for `fluent-bit.labels` to the `PodSecurityPolicy` resource which was missing it.