### PR TITLE
Make tag and matchRegex configurable in Fluent Operator Helm Chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
@@ -10,7 +10,7 @@ metadata:
     fluentbit.fluent.io/component: logging
 spec:
   tail:
-    tag: kube.*
+    tag: {{ .Values.fluentbit.input.tail.tag }}
     path: {{ .Values.fluentbit.input.tail.path }}
     readFromHead: {{ .Values.fluentbit.input.tail.readFromHead }}
     {{- if eq .Values.containerRuntime "docker" }}

--- a/charts/fluent-operator/templates/fluentbit-output-opensearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-opensearch.yaml
@@ -9,7 +9,7 @@ metadata:
     fluentbit.fluent.io/enabled: "true"
     fluentbit.fluent.io/component: logging
 spec:
-  matchRegex: (?:kube|service)\.(.*)
+  matchRegex: {{ .Values.fluentbit.output.opensearch.match }}
   opensearch:
 {{ toYaml .Values.fluentbit.output.opensearch | indent 4}}
 {{- end }}


### PR DESCRIPTION
I would like to propose changes to make the tag and matchRegex values configurable in the Fluent Operator Helm Chart.

In [fluentbit-clusterinput-tail.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml)
Replace tag: kube.* with tag: {{ .Values.fluentbit.input.tail.tag }}

In [fluentbit-output-opensearch.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-operator/templates/fluentbit-output-opensearch.yaml)
Replace matchRegex: (?:kube|service)\.(.*) with matchRegex: {{ .Values.fluentbit.output.opensearch.match }}