### PR TITLE
feat(fluent-bit) - Added namespaceOverride parameter following community's best practices

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.48.6
+version: 0.49.0
 appVersion: 3.2.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -22,5 +22,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated Fluent Bit OCI image to v3.2.6."
+    - kind: added
+      description: "Added namespaceOverride parameter following community's best practices"

--- a/charts/fluent-bit/dashboards/fluent-bit.json
+++ b/charts/fluent-bit/dashboards/fluent-bit.json
@@ -1506,7 +1506,7 @@
         "hide": 2,
         "label": "Namespace",
         "name": "namespace",
-        "query": "{{ .Release.Namespace }}",
+        "query": "{{ include "fluent-bit.namespace" .}}",
         "skipUrlSync": false,
         "type": "constant"
       },
@@ -1559,7 +1559,10 @@
   },
   "timezone": "",
   "title": "{{ include "fluent-bit.fullname" . }}",
-  "uid": {{ ternary (printf "\"%s\"" (sha1sum (printf "%s-%s" .Release.Namespace (include "fluent-bit.fullname" .)))) "null" .Values.dashboards.deterministicUid }},
+  "uid": {
+    { ternary (printf "\"%s\"" (sha1sum (printf "%s-%s" (include "fluent-bit.namespace" .) (include "fluent-bit.fullname" .)))) "null" .Values.dashboards.deterministicUid
+    }
+  },
   "version": 7,
   "weekStart": ""
 }

--- a/charts/fluent-bit/dashboards/fluent-bit.json
+++ b/charts/fluent-bit/dashboards/fluent-bit.json
@@ -1559,10 +1559,7 @@
   },
   "timezone": "",
   "title": "{{ include "fluent-bit.fullname" . }}",
-  "uid": {
-    { ternary (printf "\"%s\"" (sha1sum (printf "%s-%s" (include "fluent-bit.namespace" .) (include "fluent-bit.fullname" .)))) "null" .Values.dashboards.deterministicUid
-    }
-  },
+  "uid": {{ ternary (printf "\"%s\"" (sha1sum (printf "%s-%s" (include "fluent-bit.namespace" .) (include "fluent-bit.fullname" .)))) "null" .Values.dashboards.deterministicUid }},
   "version": 7,
   "weekStart": ""
 }

--- a/charts/fluent-bit/templates/NOTES.txt
+++ b/charts/fluent-bit/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Get Fluent Bit build information by running these commands:
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fluent-bit.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 2020:2020
-curl http://127.0.0.1:2020 
+export POD_NAME=$(kubectl get pods --namespace {{ include "fluent-bit.namespace" . }} -l "app.kubernetes.io/name={{ include "fluent-bit.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace {{ include "fluent-bit.namespace" . }} port-forward $POD_NAME 2020:2020
+curl http://127.0.0.1:2020
 

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -25,6 +25,19 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If no override is provided, the namespace will be fetched from .Release.Namespace (Helm's default)
+*/}}
+{{- define "fluent-bit.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "fluent-bit.chart" -}}

--- a/charts/fluent-bit/templates/clusterrolebinding.yaml
+++ b/charts/fluent-bit/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluent-bit.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "fluent-bit.namespace" . }}
 {{- end -}}

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" $ }}-dashboard-{{ trimSuffix ".json" (base $path) }}
-  namespace: {{ default $.Release.Namespace $.Values.dashboards.namespace }}
+  namespace: {{ default ( include "fluent-bit.namespace" $ ) $.Values.dashboards.namespace }}
   {{- with $.Values.dashboards.annotations }}
   annotations:
     {{- toYaml . | nindent 4 -}}

--- a/charts/fluent-bit/templates/configmap-luascripts.yaml
+++ b/charts/fluent-bit/templates/configmap-luascripts.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" . }}-luascripts
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/fluent-bit/templates/hpa.yaml
+++ b/charts/fluent-bit/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "fluent-bit.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit/templates/ingress.yaml
+++ b/charts/fluent-bit/templates/ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: {{ include "fluent-bit.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/fluent-bit/templates/networkpolicy.yaml
+++ b/charts/fluent-bit/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: "networking.k8s.io/v1"
 kind: "NetworkPolicy"
 metadata:
   name: {{ include "fluent-bit.fullname" . | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit/templates/pdb.yaml
+++ b/charts/fluent-bit/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "fluent-bit.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 {{- with .Values.podDisruptionBudget.annotations }}

--- a/charts/fluent-bit/templates/prometheusrule.yaml
+++ b/charts/fluent-bit/templates/prometheusrule.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ default $.Release.Namespace .Values.prometheusRule.namespace }}
+  namespace: {{ default ( include "fluent-bit.namespace" $ ) .Values.prometheusRule.namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- if .Values.prometheusRule.additionalLabels }}

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/fluent-bit/templates/serviceaccount.yaml
+++ b/charts/fluent-bit/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluent-bit.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -44,7 +44,7 @@ spec:
     {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "fluent-bit.namespace" . }}
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "fluent-bit.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  namespace: {{ default ( include "fluent-bit.namespace" . ) .Values.serviceMonitor.namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.selector }}

--- a/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "fluent-bit.fullname" . }}-test-connection"
-  namespace: {{ default .Release.Namespace .Values.testFramework.namespace }}
+  namespace: {{ default ( include "fluent-bit.namespace" . ) .Values.testFramework.namespace }}
   labels:
     helm.sh/chart: {{ include "fluent-bit.chart" . }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/fluent-bit/templates/vpa.yaml
+++ b/charts/fluent-bit/templates/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.autoscaling.vpa.annotations }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -26,6 +26,7 @@ testFramework:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 serviceAccount:
   create: true


### PR DESCRIPTION
### Why this is relevant

- My current use case is bundling fluent-bit as a subchart in another Helm Chart with a couple of other services. Most of them ([ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/de1a4c463cc63c560145eeacef842fec767a764a/charts/ingress-nginx/values.yaml#L15), [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/c5f625f8b03a7baf9fd872f5aa8f3d61b475e896/charts/kube-prometheus-stack/values.yaml#L11), [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets/blob/c66a23dd81615392637e11ce5f3578ad8b2bcfc5/helm/sealed-secrets/values.yaml#L14)) support their namespaces being overriden for this exact scenario, though this only works if the chart's maintainers implemented support for it
- This PR also solves issue #103, so it's safe to say I'm not alone in this use case!
- My current implementation borrows the implementation from @jasine in https://github.com/kubernetes/ingress-nginx/pull/10539/files, which consists of centralizing the logic of expanding the namespace name inside a function in `_helpers.tpl`. This is also consistent with the implementation of `fullnameOverride`.