### PR TITLE
feat(helm): add option to disable rbac creation

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.enable }}
+{{- if and .Values.operator.enable .Values.operator.rbac.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/fluent-operator/templates/fluent-operator-clusterRoleBinding.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.enable }}
+{{- if and .Values.operator.enable .Values.operator.rbac.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -38,6 +38,9 @@ operator:
   priorityClassName: ""
   # Pod security context for Fluent Operator. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext: {}
+  rbac:
+    # -- Specifies whether to create the ClusterRole and ClusterRoleBinding.
+    create: true  
   # Container security context for Fluent Operator container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext: {}
   # Fluent Operator resources. Usually user needn't to adjust these.


### PR DESCRIPTION
## AIM

Enable or disable ClusterRole and RoleBinding creation.
The use case is to allow users to use this chart in clusters where creating such objetcs is not allowed by helm deployment.
Also, it's adding the ability to customize the rules, as not all of them are required for the operator to work.


## How to use

To use this feature, simply update a propertie  in the values.
```
...
operator:
  rbac:
    create: true
...
```

* set `true` for enable but it's default value.
* set `false` for disable.

