### PR TITLE
port feature from fluent-bit-aggregator chart

### DIFF
--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -63,6 +63,13 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Define the headless service name
+*/}}
+{{- define "fluent-bit.headlessServiceName" -}}
+{{- (printf "%s-headless" (include "fluent-bit.fullname" .)) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Fluent-bit image with tag/digest
 */}}
 {{- define "fluent-bit.image" -}}

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -43,4 +43,7 @@ rules:
     verbs:
       - use
   {{- end }}
+  {{- with .Values.rbac.additionalRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end -}}

--- a/charts/fluent-bit/templates/configmap-luascripts.yaml
+++ b/charts/fluent-bit/templates/configmap-luascripts.yaml
@@ -7,7 +7,8 @@ metadata:
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:
-  {{ range $key, $value := .Values.luaScripts }}
-  {{ $key }}: {{ (tpl $value $) | quote }}
-  {{ end }}
+  {{- range $key, $value := .Values.luaScripts }}
+  {{ $key }}: |-
+    {{- (tpl $value $) | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/fluent-bit/templates/hpa.yaml
+++ b/charts/fluent-bit/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and  ( eq  .Values.kind "Deployment" )  .Values.autoscaling.enabled  }}
+{{- if and  ( or ( eq  .Values.kind "Deployment" ) ( eq  .Values.kind "StatefulSet" ) ) .Values.autoscaling.enabled  }}
 apiVersion: {{ include "fluent-bit.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
@@ -13,7 +13,7 @@ spec:
   {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind }}
     name: {{ include "fluent-bit.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/fluent-bit/templates/ingress.yaml
+++ b/charts/fluent-bit/templates/ingress.yaml
@@ -2,46 +2,42 @@
 {{- $ingressSupportsIngressClassName := eq (include "fluent-bit.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "fluent-bit.ingress.supportsPathType" .) "true" -}}
 {{- $fullName := include "fluent-bit.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
 
-{{- if and ( eq .Values.kind "Deployment" ) .Values.ingress.enabled }}
+{{- if or ( eq .Values.kind "Deployment" ) ( eq .Values.kind "StatefulSet" ) }}
+{{- range $i, $v := .Values.ingresses -}}
+{{- $svcPort := $v.servicePort -}}
 apiVersion: {{ include "fluent-bit.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ (printf "%s-%s" ($fullName | trunc 60) (toString $i)) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with $v.annotations }}
   annotations:
-  {{- range $key, $value := . }}
-    {{ printf "%s: %s" $key ((tpl $value $) | quote) }}
-  {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- if and $ingressSupportsIngressClassName $v.ingressClassName }}
+  ingressClassName: {{ $v.ingressClassName }}
   {{- end -}}
-  {{- if .Values.ingress.tls }}
+  {{- if $v.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+  {{- range $v.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      {{- with .secretName }}
-      secretName: {{ . }}
-      {{- end }}
-    {{- end }}
+        {{- toYaml .hosts | nindent 8 }}
+      secretName: {{ .secretName }}
+  {{- end }}
   {{- end }}
   rules:
-    {{- range concat .Values.ingress.hosts .Values.ingress.extraHosts }}
+    {{- range $v.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+        {{- range .paths }}
+          - path: {{ .path }}
             {{- if $ingressSupportsPathType }}
-            pathType: Prefix
+            pathType: {{ .pathType }}
             {{- end }}
             backend:
               {{- if $ingressApiIsStable }}
@@ -61,5 +57,7 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
               {{- end }}
+        {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/fluent-bit/templates/pdb.yaml
+++ b/charts/fluent-bit/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and  ( eq  .Values.kind "Deployment" )  .Values.podDisruptionBudget.enabled  }}
+{{- if and  (or ( eq  .Values.kind "Deployment" ) ( eq  .Values.kind "StatefulSet" )) .Values.podDisruptionBudget.enabled  }}
 apiVersion: {{ include "fluent-bit.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -11,7 +11,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}

--- a/charts/fluent-bit/templates/service-headless.yaml
+++ b/charts/fluent-bit/templates/service-headless.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluent-bit.headlessServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    prometheus.io/service-monitor: "false"
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  {{- if (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  {{- with .Values.service.trafficDistribution }}
+    trafficDistribution: {{ . }}
+  {{- end }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  {{- if .Values.extraPorts }}
+    {{- range .Values.extraPorts }}
+    - name: {{ .name }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+    {{- end }}
+  {{- end }}
+  selector:
+    {{- include "fluent-bit.selectorLabels" . | nindent 4 }}

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -37,6 +37,11 @@ spec:
   loadBalancerIP: {{ . }}
   {{- end }}
   {{- end }}
+  {{- if (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  {{- with .Values.service.trafficDistribution }}
+    trafficDistribution: {{ . }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/fluent-bit/templates/serviceaccount.yaml
+++ b/charts/fluent-bit/templates/serviceaccount.yaml
@@ -6,8 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
 {{- end -}}

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -48,4 +48,9 @@ spec:
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
 {{- end }}

--- a/charts/fluent-bit/templates/statefulset.yaml
+++ b/charts/fluent-bit/templates/statefulset.yaml
@@ -1,0 +1,78 @@
+{{- if eq .Values.kind "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "fluent-bit.headlessServiceName" . }}
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ordinals }}
+  ordinals:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fluent-bit.selectorLabels" . | nindent 6 }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluent-bit.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or (not .Values.hotReload.enabled) .Values.podAnnotations }}
+      annotations:
+      {{- if not .Values.hotReload.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.luaScripts }}
+        checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+    spec:
+      {{- include "fluent-bit.pod" . | nindent 6 }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+  {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ ternary "Retain" "Delete" .Values.persistence.retainDeleted }}
+    whenScaled: {{ ternary "Retain" "Delete" .Values.persistence.retainScaled }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -1,9 +1,9 @@
 # Default values for fluent-bit.
 
-# kind -- DaemonSet or Deployment
+# kind -- DaemonSet, Deployment or StatefulSet
 kind: DaemonSet
 
-# replicaCount -- Only applicable if kind=Deployment
+# Only applicable for Deployment or StatefulSet
 replicaCount: 1
 
 image:
@@ -29,13 +29,17 @@ fullnameOverride: ""
 
 serviceAccount:
   create: true
+  labels: {}
   annotations: {}
   name:
+  automountToken: false
 
 rbac:
   create: true
   nodeAccess: false
   eventsAccess: false
+  # -- Additional rules to add to the `ClusterRole`.
+  additionalRules: []
 
 # Configure podsecuritypolicy
 # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
@@ -216,23 +220,21 @@ resources: {}
 #     cpu: 100m
 #     memory: 128Mi
 
-## only available if kind is Deployment
-ingress:
-  enabled: false
-  ingressClassName: ""
-  annotations: {}
-  #  kubernetes.io/ingress.class: nginx
-  #  kubernetes.io/tls-acme: "true"
-  hosts: []
-  # - host: fluent-bit.example.tld
-  extraHosts: []
-  # - host: fluent-bit-extra.example.tld
-  ## specify extraPort number
-  #   port: 5170
-  tls: []
-  #  - secretName: fluent-bit-example-tld
-  #    hosts:
-  #      - fluent-bit.example.tld
+## only available if kind is Deployment or StatefulSet.
+# -- (list) Ingresses, each input plugin will need it's own.
+ingresses: []
+#  - servicePort: 24224
+#    ingressClassName: my-ingress-class
+#    annotations: {}
+#    hosts:
+#      - host: chart-example.local
+#        paths:
+#          - path: /
+#            pathType: Prefix
+#    tls:
+#      - hosts:
+#          - chart-example.local
+#        secretName: chart-example-tls
 
 ## only available if kind is Deployment
 autoscaling:
@@ -283,17 +285,52 @@ autoscaling:
 #            value: 10
 #            periodSeconds: 60
 
+# -- Ordinals configuration for the `StatefulSet`.
+ordinals: {}
+
+# -- Pod management policy for the `StatefulSet`.
+podManagementPolicy:
+
 ## only available if kind is Deployment
 podDisruptionBudget:
   enabled: false
   annotations: {}
+  # -- (string) Minimum number of available pods, either a number or a percentage.
+  minAvailable: "70%"
+  # -- (string) Maximum number of unavailable pods, either a number or a percentage.
   maxUnavailable: "30%"
+  # -- (string) Unhealthy pod eviction policy for the PDB.
+  unhealthyPodEvictionPolicy: IfHealthyBudget
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+#  podAntiAffinity:
+#    preferredDuringSchedulingIgnoredDuringExecution:
+#      - weight: 100
+#        podAffinityTerm:
+#          labelSelector:
+#            matchExpressions:
+#              - key: app.kubernetes.io/name
+#                operator: In
+#                values:
+#                  - '{{ include "fluent-bit.name" . }}'
+#              - key: app.kubernetes.io/instance
+#                operator: In
+#                values:
+#                  - "{{ .Release.Name }}"
+#          topologyKey: kubernetes.io/hostname
+
+topologySpreadConstraints: []
+#  - maxSkew: 1
+#    topologyKey: topology.kubernetes.io/zone
+#    whenUnsatisfiable: DoNotSchedule
+#    labelSelector:
+#      matchLabels:
+#        app.kubernetes.io/name: '{{ include "fluent-bit.name" . }}'
+#        app.kubernetes.io/instance: "{{ .Release.Name }}"
 
 labels: {}
 
@@ -354,6 +391,22 @@ extraPorts: []
 #     name: tcp
 #     nodePort: 30517
 
+persistence:
+  # -- If `true` , persistence should be enabled for the `StatefulSet`.
+  enabled: false
+  # -- Annotations for the `PersistentVolumeClaim`.
+  annotations: {}
+  # -- Access mode for the `PersistentVolumeClaim`.
+  accessMode: ReadWriteOnce
+  # -- Storage class for the `PersistentVolumeClaim`, if not set the default will be used.
+  storageClass:
+  # -- Size of the `PersistentVolumeClaim`.
+  size: 8Gi
+  # -- If `true`, keep `PersistentVolumeClaims` when the `StatefulSet` is deleted.
+  retainDeleted: true
+  # -- If `true`, keep `PersistentVolumeClaim` when the `StatefulSet` is scaled down.
+  retainScaled: true
+
 extraVolumes: []
 
 extraVolumeMounts: []
@@ -387,6 +440,9 @@ config:
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.metricsPort }}
         Health_Check On
+        {{- if .Values.persistence.enabled }}
+        Storage.path ${STORAGE_PATH}
+        {{- end }}
 
   ## https://docs.fluentbit.io/manual/pipeline/inputs
   inputs: |
@@ -403,6 +459,9 @@ config:
         Tag host.*
         Systemd_Filter _SYSTEMD_UNIT=kubelet.service
         Read_From_Tail On
+
+  # Storage section should be add to input when persistence enabled & kind StatefulsSet
+  # Storage.type      filesystem
 
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |


### PR DESCRIPTION
Review code on [fluent-bit-aggregator](https://github.com/stevehipwell/helm-charts/blob/main/charts/fluent-bit-aggregator) and copy some feature from the repo.
- add StatefulSet for chart fluent-bit
- add support for multiple ingresses
- add headless service
- config HPA to support both StatefulSet and Deployment
- add env on POD template
- add support for additionrules on clusterrole