### PR TITLE
fix: Invalid reference

### DIFF
--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -14,7 +14,7 @@ spec:
         bind: 0.0.0.0
         port: {{ .port }}
   replicas: {{ .replicas }}
-  image: {{ template "fluent-operator.image" (tuple .Values.fluentd.image "") }}
+  image: {{ template "fluent-operator.image" (tuple .image "") }}
   {{- with .imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
The current Chart is broken because it's incorrectly pointing to `.Values.fluend.image` while the scope is being limited to `.Values.fluend` on line 3. 