### PR TITLE
fix: support object for httpUser and httpPassword in fluentbit ES output

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -23,11 +23,23 @@ spec:
     {{- with .Values.fluentbit.output.es.index }}
     index: {{ . | quote }}
     {{- end }}
-    {{- with .Values.fluentbit.output.es.httpUser }}
-    httpUser: {{ . | quote }}
+    {{- $user := .Values.fluentbit.output.es.httpUser }}
+    {{- if $user }}
+    {{- if kindIs "map" $user }}
+    httpUser:
+    {{ toYaml $user | indent 6 }}
+    {{- else }}
+    httpUser: {{ $user | quote }}
     {{- end }}
-    {{- with .Values.fluentbit.output.es.httpPassword }}
-    httpPassword: {{ . | quote }}
+    {{- end }}
+    {{- $pass := .Values.fluentbit.output.es.httpPassword }}
+    {{- if $pass }}
+    {{- if kindIs "map" $pass }}
+    httpPassword:
+    {{ toYaml $pass | indent 6 }}
+    {{- else }}
+    httpPassword: {{ $pass | quote }}
+    {{- end }}
     {{- end }}
     logstashFormat: {{ .Values.fluentbit.output.es.logstashFormat | default true }}
     {{- with .Values.fluentbit.output.es.logstashPrefix }}


### PR DESCRIPTION
## What does this PR do?

This PR updates the fluent-operator Helm chart to support both string and object values for the `httpUser` and `httpPassword` fields in the Elasticsearch output. This is required for compatibility with recent CRDs that expect these fields to be objects when using secret references.

## Why is it needed?

Currently, the template always renders these fields as strings, which causes CRD validation errors when an object is required (e.g., for secret references). This change adds logic to render the value as an object if a map is provided, or as a string otherwise, for backward compatibility.

## How to test

- Provide an object for `httpUser`/`httpPassword` in `values.yaml`:
  ```yaml
  httpUser:
    valueFrom:
      secretKeyRef:
        name: elastic-fluent-operator-secret
        key: username
  httpPassword:
    valueFrom:
      secretKeyRef:
        name: elastic-fluent-operator-secret
        key: password
  ```
- Run `helm template` and verify the rendered manifest contains the object, not a string.

## Related issues

- CRD validation errors when using secret references for ES output
- [Reference: fluent-operator docs](https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/elasticsearch.md)

## Signed-off-by

This PR is signed off in accordance with the DCO.

---

Let me know if you need any more info or want me to add tests!