### PR TITLE
Add labels to deployment of Fluent Operator

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 3.4.2
+version: 3.4.3
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
 appVersion: "3.4.0"
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator
     {{- with .Values.operator.labels }}
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- toYaml .Values.operator.annotations | nindent 4 }}

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
   annotations:
     {{- toYaml .Values.operator.annotations | nindent 4 }}
 spec:


### PR DESCRIPTION
The current helm chart allows adding custom labels, although they are not fully propagated to the deployment.

This merge requests adds the already existing variable for labels to the deployment of Fluent Operator.