### PR TITLE
[Helm Chart]: Add automountServiceAccountToken to pod spec

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.51.0
+version: 0.52.0
 appVersion: 4.0.7
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/
@@ -23,6 +23,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Fluent Bit OCI image to 4.0.7."
-    - kind: changed
-      description: "Update ConfigMap Reloader OCI image to 0.15.0."
+      description: "Add optional automountServiceAccountToken to pod spec and service account"

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -1,4 +1,7 @@
 {{- define "fluent-bit.pod" -}}
+{{- if ne .Values.serviceAccount.automountServiceAccountToken nil }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
@@ -139,7 +142,7 @@ volumes:
 {{- if or .Values.luaScripts .Values.hotReload.enabled }}
   - name: luascripts
     configMap:
-      name: {{ include "fluent-bit.fullname" . }}-luascripts 
+      name: {{ include "fluent-bit.fullname" . }}-luascripts
 {{- end }}
 {{- if eq .Values.kind "DaemonSet" }}
   {{- toYaml .Values.daemonSetVolumes | nindent 2 }}

--- a/charts/fluent-bit/templates/serviceaccount.yaml
+++ b/charts/fluent-bit/templates/serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if ne .Values.serviceAccount.automountServiceAccountToken nil }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end -}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -31,6 +31,7 @@ serviceAccount:
   create: true
   annotations: {}
   name:
+  automountServiceAccountToken:
 
 rbac:
   create: true


### PR DESCRIPTION
Setting `automountServiceAccountToken` to false is often enforced in regulated clusters. Adding it to pod spec with the default value true.