### PR TITLE
add extra manifests template to deploy arbitary resoutces along with …

### DIFF
--- a/charts/fluent-bit/templates/extra-manifests.yaml
+++ b/charts/fluent-bit/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -525,3 +525,5 @@ hotReload:
     pullPolicy: IfNotPresent
   resources: {}
   extraWatchVolumes: []
+
+extraObjects: []


### PR DESCRIPTION
In my environment I'm using external secret operator to bring secrets to k8s and i want to mount these secrets to fluent-bit pod. It will be convenient to have all k8s resources deployed using one chart, so I added extra manifests value which helps to provide arbitrary k8s resources manifests to chart.

then it could be used like

```
extraObjects:
  - apiVersion: external-secrets.io/v1beta1
    kind: ExternalSecret
    metadata:
      name: fluent-bit-secrets
    spec:
      # ... ExternalSecret config ...
```