### PR TITLE
feat(fluentd): add StatefulSet enhancements and headless service support

### DIFF
--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -174,6 +174,24 @@ The `fileConfigs` section is organized by sources -> filters -> destinations. Fl
   </label>
 ```
 
+## Headless Service
+
+The chart supports deploying a headless service, which is useful for StatefulSet deployments where you need direct pod DNS resolution (e.g., `pod-0.fluentd-headless.namespace.svc.cluster.local`).
+
+To enable the headless service, configure the following values:
+
+```yaml
+headlessService:
+  enabled: true
+  annotations: {}
+  ports:
+    - name: "forwarder"
+      protocol: TCP
+      containerPort: 24224
+```
+
+The headless service will be created with the name `<release-name>-fluentd-headless` and will expose the metrics port (24231) by default, plus any additional ports specified in `headlessService.ports`.
+
 ## Backwards Compatibility - v0.1.x
 
 The old fluentd chart used the ENV variables and the default fluentd container definitions to set-up automatically many aspects of fluentd. It is still possible to trigger this behaviour by removing this charts current `.Values.env` configuration and replace by:

--- a/charts/fluentd/templates/headless-service.yaml
+++ b/charts/fluentd/templates/headless-service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.headlessService.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluentd.fullname" . }}-headless
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+  {{- with .Values.headlessService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - port: 24231
+    targetPort: metrics
+    protocol: TCP
+    name: metrics
+  {{- if .Values.headlessService.ports }}
+  {{- range $port := .Values.headlessService.ports }}
+  - name: {{ $port.name }}
+    port: {{ $port.containerPort }}
+    targetPort: {{ $port.containerPort }}
+    protocol: {{ $port.protocol }}
+  {{- end }}
+  {{- end }}
+  selector:
+    {{- include "fluentd.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/fluentd/templates/hpa.yaml
+++ b/charts/fluentd/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and  ( eq  .Values.kind "Deployment" )  .Values.autoscaling.enabled  }}
+{{- if .Values.autoscaling.enabled  }}
 apiVersion: {{ include "fluentd.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
@@ -12,7 +12,7 @@ spec:
   {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind }}
     name: {{ include "fluentd.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/fluentd/templates/pdb.yaml
+++ b/charts/fluentd/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "fluentd.fullname" . }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fluentd.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -13,7 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   serviceName: {{ include "fluentd.fullname" . }}
   {{- with .Values.updateStrategy }}
   updateStrategy:

--- a/charts/fluentd/templates/statefulset.yaml
+++ b/charts/fluentd/templates/statefulset.yaml
@@ -25,6 +25,10 @@ spec:
   {{- with .Values.minReadySeconds }}
   minReadySeconds: {{ . }}
   {{- end }}
+  {{- with .Values.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -161,6 +161,15 @@ updateStrategy: {}
 #   rollingUpdate:
 #     maxUnavailable: 1
 
+persistentVolumeClaimRetentionPolicy: {}
+#  whenDeleted: Delete
+#  whenScaled: Delete
+
+podDisruptionBudget:
+  enabled: false
+#  minAvailable: 1
+#  maxUnavailable: 1
+
 ## Additional environment variables to set for fluentd pods
 env: []
   # - name: "FLUENTD_CONF"

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -219,6 +219,16 @@ service:
   #   protocol: TCP
   #   containerPort: 24224
 
+## Headless service for StatefulSet
+##
+headlessService:
+  enabled: false
+  annotations: {}
+  ports: []
+  # - name: "forwarder"
+  #   protocol: TCP
+  #   containerPort: 24224
+
 ## Prometheus Monitoring
 ##
 metrics:


### PR DESCRIPTION
## Summary

This PR adds several enhancements to the fluentd chart, primarily focused on improving StatefulSet deployments:

### New Features

1. **Headless Service Support**
   - Added new `headlessService` configuration to enable headless services for StatefulSet deployments
   - Enables direct pod DNS resolution (e.g., `pod-0.fluentd-headless.namespace.svc.cluster.local`)
   - Configurable annotations and additional ports

2. **PersistentVolumeClaimRetentionPolicy Support**
   - Added `persistentVolumeClaimRetentionPolicy` configuration for StatefulSets
   - Allows control over PVC retention when pods are deleted or scaled down

3. **PodDisruptionBudget (PDB) Support**
   - Added new `pdb.yaml` template
   - Configurable `minAvailable` and `maxUnavailable` settings
   - Helps ensure availability during voluntary disruptions

4. **HPA Support for StatefulSet**
   - Extended HorizontalPodAutoscaler to work with StatefulSet (previously only Deployment)
   - Dynamic `kind` reference based on `.Values.kind`

5. **Conditional Replicas for StatefulSet**
   - StatefulSet `replicas` field is now only set when autoscaling is disabled
   - Prevents conflicts between HPA and static replica count

### Changed Files

| File | Change |
|------|--------|
| `charts/fluentd/values.yaml` | Added `persistentVolumeClaimRetentionPolicy`, `podDisruptionBudget`, and `headlessService` configurations |
| `charts/fluentd/templates/statefulset.yaml` | Added conditional replicas and persistentVolumeClaimRetentionPolicy support |
| `charts/fluentd/templates/hpa.yaml` | Extended to support both Deployment and StatefulSet kinds |
| `charts/fluentd/templates/pdb.yaml` | New template for PodDisruptionBudget |
| `charts/fluentd/templates/headless-service.yaml` | New template for headless service |
| `charts/fluentd/README.md` | Added documentation for headless service |

### Example Usage

```yaml
# Enable headless service for StatefulSet
headlessService:
  enabled: true
  annotations: {}
  ports:
    - name: "forwarder"
      protocol: TCP
      containerPort: 24224

# Configure PVC retention policy
persistentVolumeClaimRetentionPolicy:
  whenDeleted: Delete
  whenScaled: Delete

# Enable PodDisruptionBudget
podDisruptionBudget:
  enabled: true
  minAvailable: 1

# Enable HPA for StatefulSet
kind: StatefulSet
autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 10
  targetCPUUtilizationPercentage: 80
```