### PR TITLE
feat(fluent-bit): support various overrides on fluent-bit service.yaml

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.54.0
+version: 0.54.1
 appVersion: 4.1.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -41,7 +41,8 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      appProtocol: {{ default "http" .Values.service.appProtocol }}
+      name: {{ default "http" .Values.service.name }}
       {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -99,8 +99,10 @@ securityContext: {}
 #   runAsUser: 1000
 
 service:
+  name: http
   type: ClusterIP
   port: 2020
+  appProtocol: http
   internalTrafficPolicy:
   loadBalancerClass:
   loadBalancerSourceRanges: []


### PR DESCRIPTION
Istio by default is interpreting the protocol via protocol selection.  https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

Current configuration breaks as the Istio sidecar doesn't seem to be able to pass HTTP content over to the HTTP Metrics API with the default service configuration:

```
    [SERVICE]
        Daemon Off
        Flush 1
        Log_Level info
        Parsers_File /fluent-bit/etc/parsers.conf
        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
        HTTP_Server On
        HTTP_Listen 0.0.0.0
        HTTP_Port 2020
        Health_Check On
```

If we change the `name:` prefix to `tcp` instead, Istio seems happier with this and doesn't give the typical 503 error. 

This change just gives basic support for changing attributes in the service.yaml that users might need access to. 