### PR TITLE
Fix typo in container runtime example values

### DIFF
--- a/charts/fluent-operator/README.md
+++ b/charts/fluent-operator/README.md
@@ -7,7 +7,7 @@
 To install or upgrade Fluent Operator using Helm:
 
 ```shell
-export FLUENT_OPERATOR_CONTAINER_RUNTIME="containerd" # or "cri-o", "docker" depending on the container runtime being used (see `values.yaml`)
+export FLUENT_OPERATOR_CONTAINER_RUNTIME="containerd" # or "crio", "docker" depending on the container runtime being used (see `values.yaml`)
 
 helm repo add fluent https://fluent.github.io/helm-charts
 helm upgrade --install fluent-operator fluent/fluent-operator \


### PR DESCRIPTION
Sure it's spelled `cri-o`, but the templates check for `crio`

    {{- else if eq .Values.containerRuntime "crio" }}