### PR TITLE
feat(fluent-bit): Ability to specify ingress path

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.54.0
+version: 0.54.1
 appVersion: 4.1.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/templates/ingress.yaml
+++ b/charts/fluent-bit/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ default "/" .path }}
             {{- if $ingressSupportsPathType }}
             pathType: Prefix
             {{- end }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -230,6 +230,8 @@ ingress:
   # - host: fluent-bit-extra.example.tld
   ## specify extraPort number
   #   port: 5170
+  ## specify path
+  #   path: /example
   tls: []
   #  - secretName: fluent-bit-example-tld
   #    hosts:


### PR DESCRIPTION
This adds an ability to specify ingress path.

This is completely backwards-compatible. If the path is not provided, `/` is used as the default, identically as before.