### PR TITLE
fix(fluent-bit): support additionalLabels in ServiceMonitor

### DIFF
--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Changed
+
+- **BREAKING**: Renamed `serviceMonitor.selector` to `serviceMonitor.additionalLabels` for consistency with PrometheusRule configuration. ([#691](https://github.com/fluent/helm-charts/pull/691)) _@kalavt_
+
 ## [v0.55.0] - 2026-01-22
 
 ### Changed

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -8,10 +8,6 @@ metadata:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
-    {{- else }}
-    {{- with .Values.serviceMonitor.selector }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     {{- end }}
 spec:
   jobLabel: app.kubernetes.io/instance

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -6,8 +6,12 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
     {{- with .Values.serviceMonitor.selector }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   jobLabel: app.kubernetes.io/instance

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -121,13 +121,9 @@ serviceMonitor:
   #   namespace: monitoring
   #   interval: 10s
   #   scrapeTimeout: 10s
-  #   ## additionalLabels: Additional labels to add to the ServiceMonitor metadata
-  #   ## This is the recommended way to add labels for Prometheus Operator selection
-  #   additionalLabels: {}
-  #   #  prometheus: my-prometheus
-  #   ## selector: (DEPRECATED) Use additionalLabels instead
-  #   ## This field is maintained for backward compatibility but additionalLabels is preferred
-  #   selector: {}
+  #   additionalLabels:
+  #     prometheus: kube-prometheus
+  #     release: prometheus
   #  ## metric relabel configs to apply to samples before ingestion.
   #  ##
   #  metricRelabelings:

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -121,8 +121,13 @@ serviceMonitor:
   #   namespace: monitoring
   #   interval: 10s
   #   scrapeTimeout: 10s
-  #   selector:
-  #    prometheus: my-prometheus
+  #   ## additionalLabels: Additional labels to add to the ServiceMonitor metadata
+  #   ## This is the recommended way to add labels for Prometheus Operator selection
+  #   additionalLabels: {}
+  #   #  prometheus: my-prometheus
+  #   ## selector: (DEPRECATED) Use additionalLabels instead
+  #   ## This field is maintained for backward compatibility but additionalLabels is preferred
+  #   selector: {}
   #  ## metric relabel configs to apply to samples before ingestion.
   #  ##
   #  metricRelabelings:


### PR DESCRIPTION
# PR: Rename serviceMonitor.selector to serviceMonitor.additionalLabels (Breaking Change)

## Summary

This PR renames `serviceMonitor.selector` to `serviceMonitor.additionalLabels` to align with PrometheusRule's naming convention and eliminate confusion with ServiceMonitor's `spec.selector` field.

## Problem Statement

Currently, the ServiceMonitor template uses `.Values.serviceMonitor.selector` for metadata labels, which:

1. Is inconsistent with PrometheusRule which uses `additionalLabels`
2. Creates confusion with `spec.selector` (the ServiceMonitor's pod selector field)
3. Results in poor discoverability when Prometheus cannot find ServiceMonitors without proper labels

Example of the current confusing configuration:

```yaml
serviceMonitor:
  enabled: true
  namespace: observability
  selector:  # Unclear - is this metadata labels or spec.selector?
    prometheus: kube-prometheus
    release: prometheus
```

Users often struggle to understand why their ServiceMonitor isn't being discovered by Prometheus, not realizing these are metadata labels, not the spec selector.

## Solution

Replace `serviceMonitor.selector` with `serviceMonitor.additionalLabels` for clear semantics:

```yaml
serviceMonitor:
  enabled: true
  namespace: observability
  additionalLabels:  # Clear - these are metadata labels
    prometheus: kube-prometheus
    release: prometheus
```

## Why Breaking Change is Acceptable

This is a **breaking change** but acceptable because:

1. **Pre-release status**: Chart version is v0.55.0 (v0.x series), where breaking changes are expected per semantic versioning
2. **Simple migration**: Users only need to rename one parameter in their values.yaml
3. **Long-term benefits**: No deprecated code to maintain, cleaner codebase
4. **Clear documentation**: Breaking change is clearly documented in CHANGELOG

## Benefits

1. **Consistent Naming** - Aligns with PrometheusRule configuration pattern
2. **Clear Semantics** - `additionalLabels` clearly indicates these are metadata labels, not pod selectors
3. **No Technical Debt** - No deprecated parameters to maintain
4. **Better UX** - Reduces confusion and improves discoverability

## Changes

### Files Modified

1. **templates/servicemonitor.yaml**
   - Changed metadata labels from `.Values.serviceMonitor.selector` to `.Values.serviceMonitor.additionalLabels`

2. **values.yaml**
   - Renamed `selector` parameter to `additionalLabels` in serviceMonitor section
   - Updated documentation comments

3. **CHANGELOG.md**
   - Added breaking change entry under [UNRELEASED]

## Migration Guide

Users need to update their values.yaml:

**Before:**

```yaml
serviceMonitor:
  selector:
    prometheus: kube-prometheus
    release: prometheus
```

**After:**

```yaml
serviceMonitor:
  additionalLabels:
    prometheus: kube-prometheus
    release: prometheus
```

## Testing

```bash
# Test with additionalLabels
helm template test charts/fluent-bit \
  --set serviceMonitor.enabled=true \
  --set serviceMonitor.additionalLabels.prometheus=kube-prometheus \
  --set serviceMonitor.additionalLabels.release=prometheus

# Verify lint passes
helm lint charts/fluent-bit

# Verify documentation is updated
just docs
```

## Checklist

- [x] Breaking change documented in CHANGELOG.md
- [x] values.yaml updated with new parameter name
- [x] servicemonitor.yaml template updated
- [x] helm-docs comments updated in values.yaml
- [x] Documentation regenerated with `just docs`
- [x] Markdown formatted with `just fmt`
- [x] Helm lint passes
- [x] Testing completed with new parameter
- [x] DCO sign-off included in commits
