### PR TITLE
feat: add namespaceOverride option

### DIFF
--- a/charts/fluent-bit-aggregator/templates/_helpers.tpl
+++ b/charts/fluent-bit-aggregator/templates/_helpers.tpl
@@ -24,6 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "fluent-bit-aggregator.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "fluent-bit-aggregator.chart" -}}

--- a/charts/fluent-bit-aggregator/templates/clusterrole.yaml
+++ b/charts/fluent-bit-aggregator/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "fluent-bit-aggregator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 rules:

--- a/charts/fluent-bit-aggregator/templates/clusterrolebinding.yaml
+++ b/charts/fluent-bit-aggregator/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "fluent-bit-aggregator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 roleRef:
@@ -13,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluent-bit-aggregator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "fluent-bit-aggregator.namespace" . }}
 {{- end }}

--- a/charts/fluent-bit-aggregator/templates/configmap-config.yaml
+++ b/charts/fluent-bit-aggregator/templates/configmap-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit-aggregator.configConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit-aggregator/templates/configmap-dashboard.yaml
+++ b/charts/fluent-bit-aggregator/templates/configmap-dashboard.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit-aggregator.dashboardConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
     grafana_dashboard: "1"

--- a/charts/fluent-bit-aggregator/templates/configmap-scripts.yaml
+++ b/charts/fluent-bit-aggregator/templates/configmap-scripts.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit-aggregator.scriptsConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit-aggregator/templates/hpa.yaml
+++ b/charts/fluent-bit-aggregator/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fluent-bit-aggregator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit-aggregator/templates/ingress.yaml
+++ b/charts/fluent-bit-aggregator/templates/ingress.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ (printf "%s-%s" ((include "fluent-bit-aggregator.fullname" $) | trunc 60) (toString $i)) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" $ }}
   labels:
     {{- include "fluent-bit-aggregator.labels" $ | nindent 4 }}
   {{- with $v.annotations }}

--- a/charts/fluent-bit-aggregator/templates/pdb.yaml
+++ b/charts/fluent-bit-aggregator/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fluent-bit-aggregator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit-aggregator/templates/service-headless.yaml
+++ b/charts/fluent-bit-aggregator/templates/service-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "fluent-bit-aggregator.headlessServiceName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/charts/fluent-bit-aggregator/templates/service.yaml
+++ b/charts/fluent-bit-aggregator/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "fluent-bit-aggregator.serviceName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/fluent-bit-aggregator/templates/serviceaccount.yaml
+++ b/charts/fluent-bit-aggregator/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluent-bit-aggregator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.labels }}

--- a/charts/fluent-bit-aggregator/templates/servicemonitor.yaml
+++ b/charts/fluent-bit-aggregator/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "fluent-bit-aggregator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
   {{- with .Values.serviceMonitor.additionalLabels }}
@@ -13,7 +13,7 @@ spec:
   jobLabel: app.kubernetes.io/instance
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "fluent-bit-aggregator.namespace" . }}
   selector:
     matchLabels:
       {{- include "fluent-bit-aggregator.selectorLabels" . | nindent 6 }}

--- a/charts/fluent-bit-aggregator/templates/statefulset.yaml
+++ b/charts/fluent-bit-aggregator/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "fluent-bit-aggregator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-aggregator.namespace" . }}
   labels:
     {{- include "fluent-bit-aggregator.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit-aggregator/values.yaml
+++ b/charts/fluent-bit-aggregator/values.yaml
@@ -21,6 +21,9 @@ nameOverride:
 # -- (string) Override the full name of the chart.
 fullnameOverride:
 
+# -- (string) Override the namespace of the chart.
+namespaceOverride:
+
 # -- Labels to add to all chart resources.
 commonLabels: {}
 

--- a/charts/fluent-bit-collector/templates/_helpers.tpl
+++ b/charts/fluent-bit-collector/templates/_helpers.tpl
@@ -24,6 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "fluent-bit-collector.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "fluent-bit-collector.chart" -}}

--- a/charts/fluent-bit-collector/templates/clusterrole.yaml
+++ b/charts/fluent-bit-collector/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "fluent-bit-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
 rules:

--- a/charts/fluent-bit-collector/templates/clusterrolebinding.yaml
+++ b/charts/fluent-bit-collector/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "fluent-bit-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
 roleRef:
@@ -13,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluent-bit-collector.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "fluent-bit-collector.namespace" . }}
 {{- end }}

--- a/charts/fluent-bit-collector/templates/configmap-config.yaml
+++ b/charts/fluent-bit-collector/templates/configmap-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit-collector.configConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit-collector/templates/configmap-dashboard.yaml
+++ b/charts/fluent-bit-collector/templates/configmap-dashboard.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit-collector.dashboardConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
     grafana_dashboard: "1"

--- a/charts/fluent-bit-collector/templates/configmap-scripts.yaml
+++ b/charts/fluent-bit-collector/templates/configmap-scripts.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit-collector.scriptsConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit-collector/templates/daemonset.yaml
+++ b/charts/fluent-bit-collector/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "fluent-bit-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit-collector/templates/podmonitor.yaml
+++ b/charts/fluent-bit-collector/templates/podmonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "fluent-bit-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
   {{- with .Values.serviceMonitor.additionalLabels }}
@@ -13,7 +13,7 @@ spec:
   jobLabel: app.kubernetes.io/instance
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "fluent-bit-collector.namespace" . }}
   selector:
     matchLabels:
       {{- include "fluent-bit-collector.selectorLabels" . | nindent 6 }}

--- a/charts/fluent-bit-collector/templates/service.yaml
+++ b/charts/fluent-bit-collector/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "fluent-bit-collector.serviceName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/fluent-bit-collector/templates/serviceaccount.yaml
+++ b/charts/fluent-bit-collector/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluent-bit-collector.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.labels }}

--- a/charts/fluent-bit-collector/templates/servicemonitor.yaml
+++ b/charts/fluent-bit-collector/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "fluent-bit-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit-collector.namespace" . }}
   labels:
     {{- include "fluent-bit-collector.labels" . | nindent 4 }}
   {{- with .Values.serviceMonitor.additionalLabels }}
@@ -13,7 +13,7 @@ spec:
   jobLabel: app.kubernetes.io/instance
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "fluent-bit-collector.namespace" . }}
   selector:
     matchLabels:
       {{- include "fluent-bit-collector.selectorLabels" . | nindent 6 }}

--- a/charts/fluent-bit-collector/values.yaml
+++ b/charts/fluent-bit-collector/values.yaml
@@ -21,6 +21,9 @@ nameOverride:
 # -- (string) Override the full name of the chart.
 fullnameOverride:
 
+# -- (string) Override the namespace of the chart.
+namespaceOverride:
+
 # -- Labels to add to all chart resources.
 commonLabels: {}
 

--- a/charts/fluent-bit/templates/NOTES.txt
+++ b/charts/fluent-bit/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Get Fluent Bit build information by running these commands:
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fluent-bit.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 2020:2020
+export POD_NAME=$(kubectl get pods --namespace {{ include "fluent-bit.namespace" . }} -l "app.kubernetes.io/name={{ include "fluent-bit.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace {{ include "fluent-bit.namespace" . }} port-forward $POD_NAME 2020:2020
 curl http://127.0.0.1:2020 
 

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "fluent-bit.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "fluent-bit.chart" -}}

--- a/charts/fluent-bit/templates/clusterrolebinding.yaml
+++ b/charts/fluent-bit/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluent-bit.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "fluent-bit.namespace" . }}
 {{- end -}}

--- a/charts/fluent-bit/templates/configmap-dashboards.yaml
+++ b/charts/fluent-bit/templates/configmap-dashboards.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" $ }}-dashboard-{{ trimSuffix ".json" (base $path) }}
-  namespace: {{ default $.Release.Namespace $.Values.dashboards.namespace }}
+  namespace: {{ default (include "fluent-bit.namespace" $) $.Values.dashboards.namespace }}
   {{- with $.Values.dashboards.annotations }}
   annotations:
     {{- toYaml . | nindent 4 -}}

--- a/charts/fluent-bit/templates/configmap-luascripts.yaml
+++ b/charts/fluent-bit/templates/configmap-luascripts.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" . }}-luascripts
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 data:

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/fluent-bit/templates/deployment.yaml
+++ b/charts/fluent-bit/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/fluent-bit/templates/hpa.yaml
+++ b/charts/fluent-bit/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "fluent-bit.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit/templates/ingress.yaml
+++ b/charts/fluent-bit/templates/ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: {{ include "fluent-bit.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/fluent-bit/templates/networkpolicy.yaml
+++ b/charts/fluent-bit/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: "networking.k8s.io/v1"
 kind: "NetworkPolicy"
 metadata:
   name: {{ include "fluent-bit.fullname" . | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 spec:

--- a/charts/fluent-bit/templates/pdb.yaml
+++ b/charts/fluent-bit/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "fluent-bit.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 {{- with .Values.podDisruptionBudget.annotations }}

--- a/charts/fluent-bit/templates/prometheusrule.yaml
+++ b/charts/fluent-bit/templates/prometheusrule.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ default $.Release.Namespace .Values.prometheusRule.namespace }}
+  namespace: {{ default (include "fluent-bit.namespace" $) .Values.prometheusRule.namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- if .Values.prometheusRule.additionalLabels }}

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/fluent-bit/templates/serviceaccount.yaml
+++ b/charts/fluent-bit/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluent-bit.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/fluent-bit/templates/servicemonitor.yaml
+++ b/charts/fluent-bit/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "fluent-bit.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  namespace: {{ default (include "fluent-bit.namespace" .) .Values.serviceMonitor.namespace }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.selector }}
@@ -44,7 +44,7 @@ spec:
     {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "fluent-bit.namespace" . }}
   selector:
     matchLabels:
       {{- include "fluent-bit.selectorLabels" . | nindent 6 }}

--- a/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "fluent-bit.fullname" . }}-test-connection"
-  namespace: {{ default .Release.Namespace .Values.testFramework.namespace }}
+  namespace: {{ default (include "fluent-bit.namespace" .) .Values.testFramework.namespace }}
   labels:
     helm.sh/chart: {{ include "fluent-bit.chart" . }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/fluent-bit/templates/vpa.yaml
+++ b/charts/fluent-bit/templates/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "fluent-bit.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "fluent-bit.namespace" . }}
   labels:
     {{- include "fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.autoscaling.vpa.annotations }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -26,6 +26,7 @@ testFramework:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 serviceAccount:
   create: true

--- a/charts/fluentd/templates/NOTES.txt
+++ b/charts/fluentd/templates/NOTES.txt
@@ -1,5 +1,5 @@
 Get Fluentd build information by running these commands:
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fluentd.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 24231:24231
+export POD_NAME=$(kubectl get pods --namespace {{ include "fluentd.namespace" . }} -l "app.kubernetes.io/name={{ include "fluentd.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace {{ include "fluentd.namespace" . }} port-forward $POD_NAME 24231:24231
 curl http://127.0.0.1:24231/metrics

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "fluentd.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "fluentd.chart" -}}

--- a/charts/fluentd/templates/clusterrolebinding.yaml
+++ b/charts/fluentd/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluentd.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "fluentd.namespace" . }}
 {{- end -}}

--- a/charts/fluentd/templates/configmap-dashboards.yaml
+++ b/charts/fluentd/templates/configmap-dashboards.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dashboard-{{ trimSuffix ".json" (base $path) }}-{{ include "fluentd.shortReleaseName" $ }}
-  namespace: {{ $.Values.dashboards.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Values.dashboards.namespace | default (include "fluentd.namespace" $) }}
   labels:
     {{- include "fluentd.labels" $ | nindent 4 }}
     {{- range $key, $val := $.Values.dashboards.labels }}

--- a/charts/fluentd/templates/servicemonitor.yaml
+++ b/charts/fluentd/templates/servicemonitor.yaml
@@ -36,7 +36,7 @@ spec:
   {{ else }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "fluentd.namespace" . }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -1,5 +1,6 @@
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 # DaemonSet, Deployment or StatefulSet
 kind: "DaemonSet"


### PR DESCRIPTION
### Summary

Add support for `namespaceOverride` across all charts that were missing it: **fluent-bit**, **fluent-bit-aggregator**, **fluent-bit-collector**, and **fluentd**. The `fluent-operator` chart already had this feature.

This allows deploying chart resources into a namespace different from the Helm release namespace, which is useful for multi-namespace deployments and combined/umbrella charts.

### Changes

- **`_helpers.tpl`**: Added a `<chart>.namespace` template helper to each chart that returns `.Values.namespaceOverride` if set, otherwise falls back to `.Release.Namespace`.
- **`values.yaml`**: Added `namespaceOverride` value (defaults to empty) to each chart.
- **All templates**: Replaced hardcoded `{{ .Release.Namespace }}` references with `{{ include "<chart>.namespace" . }}` across all resource templates.

### Affected Charts

| Chart | Files Changed |
|---|---|
| `fluent-bit` | 17 templates + `values.yaml` |
| `fluent-bit-aggregator` | 13 templates + `values.yaml` |
| `fluent-bit-collector` | 10 templates + `values.yaml` |
| `fluentd` | 4 templates + `values.yaml` |

### Usage

```yaml
# Override the namespace for all chart resources
namespaceOverride: "custom-namespace"
```

When `namespaceOverride` is not set, behaviour is unchanged — resources are deployed to the Helm release namespace as before.

### Backwards Compatibility

This change is fully backwards compatible. When `namespaceOverride` is empty or unset, the helper falls back to `.Release.Namespace`, preserving existing behaviour.

### Fixes
- #291
- #103