### PR TITLE
feat(fluent-bit): Use health endpoint for liveness probe

### DIFF
--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -201,7 +201,7 @@ lifecycle: {}
 
 livenessProbe:
   httpGet:
-    path: /
+    path: /api/v2/health
     port: http
 
 readinessProbe:


### PR DESCRIPTION
Kubernetes uses the readinessProbe to determine when it should send traffic to a pod. This behavior does not make sense when applied to fluent-bit because fluent-bit is not an application that ordinarily receives traffic. Instead, it collects data itself and sends it outward.

In my opinion it would make sense to configure the health as liveness probe because using it in a readiness probe is pretty pointless. Using it as a liveness probe causes an actual effect by restarting the pod if fluent-bit cannot perform it's job.