### PR TITLE
feat(fluentd): Add support for tpl evaluation in pod annotations

### DIFF
--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [0.5.4] - 2026-04-14
+### Added
+- Support `tpl` evaluation in `podAnnotations` to allow dynamic checksums from parent charts.

--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [0.5.4] - 2026-04-14
+## [0.5.3] - 2026-04-14
 ### Added
 - Support `tpl` evaluation in `podAnnotations` to allow dynamic checksums from parent charts.

--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Added
 
+- Support `tpl` evaluation in `podAnnotations` to allow dynamic checksums from parent charts. ([#709](https://github.com/fluent/helm-charts/pull/709)) @elimayost
 - Add `variantVersion` value to specify the version of the variant to use. ([#720](https://github.com/fluent/helm-charts/pull/720)) @stevehipwell
 
 ### Changed

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -27,8 +27,8 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/fluentd-configurations-cm.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ printf "%s: %s" $k ((tpl $v $) | quote) }}
         {{- end }}
       labels:
         {{- include "fluentd.selectorLabels" . | nindent 8 }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -138,7 +138,7 @@ annotations: {}
 ##
 labels: {}
 
-## Annotations to be added to fluentd pods
+## Annotations to be added to fluentd pods. Supports tpl evaluation.
 ##
 podAnnotations: {}
 

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -140,7 +140,7 @@ annotations: {}
 ##
 labels: {}
 
-## Annotations to be added to fluentd pods
+## Annotations to be added to fluentd pods. Supports tpl evaluation.
 ##
 podAnnotations: {}
 


### PR DESCRIPTION
**Description**

This PR enables tpl evaluation within the podAnnotations loop of the Fluentd DaemonSet.

Why? The current toYaml implementation treats annotation values as static strings. By using tpl, users can pass dynamic template logic into annotations via values.yaml.

Use Case: This is specifically useful when using Fluentd as a subchart. It allows a parent chart to inject dynamic file-based checksums (e.g., checksum/config: '{{ include "parent.configHash" . }}'), solving the issue of triggering rolling restarts when external configurations change.

Changes:

    Replaced static toYaml with a range loop and tpl function in daemonset.yaml.

    Maintained backward compatibility for existing static annotations.