### PR TITLE
chore: update fluent-operator charts to v4.1.0 (appVersion 3.8.0)

### DIFF
--- a/charts/fluent-operator-fluent-bit-crds/CHANGELOG.md
+++ b/charts/fluent-operator-fluent-bit-crds/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## [UNRELEASED]
 
+## [v4.1.0] - 2026-05-21
+
+### Changed
+
+- Updates to CRDs for fluent-operator v3.8.0 compatibility
+
 ## [v4.0.0] - 2026-04-19
 
 ### Changed
@@ -24,4 +30,5 @@
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator-crds-fluent-bit
+[v4.1.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-operator-crds-fluent-bit-4.1.0
 [v4.0.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-operator-crds-fluent-bit-4.0.0

--- a/charts/fluent-operator-fluent-bit-crds/Chart.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: fluent-operator-fluent-bit-crds
 description: Custom Resource Definitions (CRDs) for Fluent Bit. Provides full Helm lifecycle management for all Fluent Bit CRDs used by Fluent Operator.
 type: application
-version: 4.0.0
+version: 4.1.0
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
-appVersion: 3.7.0
+appVersion: 3.8.0
 keywords:
   - logging
   - fluent-bit

--- a/charts/fluent-operator-fluent-bit-crds/README.md
+++ b/charts/fluent-operator-fluent-bit-crds/README.md
@@ -1,6 +1,6 @@
 # fluent-operator-fluent-bit-crds
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.7.0](https://img.shields.io/badge/AppVersion-3.7.0-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
 
 Custom Resource Definitions (CRDs) for Fluent Bit. Provides full Helm lifecycle management for all Fluent Bit CRDs used by Fluent Operator.
 
@@ -25,7 +25,7 @@ Custom Resource Definitions (CRDs) for Fluent Bit. Provides full Helm lifecycle 
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install fluent-operator-fluent-bit-crds oci://ghcr.io/fluent/helm-charts/fluent-operator-fluent-bit-crds --version 4.0.0
+helm upgrade --install fluent-operator-fluent-bit-crds oci://ghcr.io/fluent/helm-charts/fluent-operator-fluent-bit-crds --version 4.1.0
 ```
 
 #### Verification
@@ -33,7 +33,7 @@ helm upgrade --install fluent-operator-fluent-bit-crds oci://ghcr.io/fluent/helm
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-operator-fluent-bit-crds:4.0.0
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-operator-fluent-bit-crds:4.1.0
 ```
 
 ### Non-OCI Repository
@@ -42,7 +42,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add fluent https://fluent.github.io/helm-charts/
-helm upgrade --install fluent-operator-fluent-bit-crds fluent/fluent-operator-fluent-bit-crds --version 4.0.0
+helm upgrade --install fluent-operator-fluent-bit-crds fluent/fluent-operator-fluent-bit-crds --version 4.1.0
 ```
 
 ## Values

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -344,6 +344,16 @@ spec:
                   hotReload:
                     description: If true enable reloading via HTTP
                     type: boolean
+                  hotReloadEnsureThreadSafety:
+                    description: If true, preserve thread safety during hot reload
+                      by waiting for in-flight work to drain before reloading; this
+                      wait can be bounded by hotReloadTimeout.
+                    type: boolean
+                  hotReloadTimeout:
+                    description: Maximum time in seconds to wait for a hot reload
+                      to complete before aborting.
+                    format: int32
+                    type: integer
                   httpListen:
                     description: Address to listen
                     pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusterinputs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusterinputs.yaml
@@ -353,6 +353,21 @@ spec:
                   kubeURL:
                     description: API Server end-point
                     type: string
+                  pauseOnChunksOverlimit:
+                    description: Specifies if the input plugin should be paused (stop
+                      ingesting new data) when the storage.max_chunks_up value is
+                      reached.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
+                  storageType:
+                    description: Specifies the buffering mechanism for use with the
+                      input plugin, requires storage.path to be set in the service.
+                    enum:
+                    - filesystem
+                    - memory
+                    type: string
                   tag:
                     description: Tag name associated to all records coming from this
                       plugin.

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4237,6 +4237,12 @@ spec:
                     description: Limit the maximum number of Chunks in the filesystem
                       for the current output logical destination.
                     type: string
+                  workers:
+                    description: Enables dedicated thread(s) for this output. Default
+                      value is set since version 1.8.13. For previous versions is
+                      0.
+                    format: int32
+                    type: integer
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_collectors.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_collectors.yaml
@@ -2823,7 +2823,7 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        The volume will be mounted read-only (ro).
                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
@@ -2995,8 +2995,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_fluentbitconfigs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_fluentbitconfigs.yaml
@@ -376,6 +376,16 @@ spec:
                   hotReload:
                     description: If true enable reloading via HTTP
                     type: boolean
+                  hotReloadEnsureThreadSafety:
+                    description: If true, preserve thread safety during hot reload
+                      by waiting for in-flight work to drain before reloading; this
+                      wait can be bounded by hotReloadTimeout.
+                    type: boolean
+                  hotReloadTimeout:
+                    description: Maximum time in seconds to wait for a hot reload
+                      to complete before aborting.
+                    format: int32
+                    type: integer
                   httpListen:
                     description: Address to listen
                     pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_fluentbits.yaml
@@ -1043,7 +1043,6 @@ spec:
                       procMount denotes the type of proc mount to use for the containers.
                       The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
@@ -2488,7 +2487,6 @@ spec:
                             procMount denotes the type of proc mount to use for the containers.
                             The default value is Default which uses the container runtime defaults for
                             readonly paths and masked paths.
-                            This requires the ProcMountType feature flag to be enabled.
                             Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
@@ -4101,7 +4099,7 @@ spec:
                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                      The volume will be mounted read-only (ro).
                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                     properties:
@@ -4267,8 +4265,7 @@ spec:
                     description: |-
                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                      is on.
+                      are redirected to the pxd.portworx.com CSI driver.
                     properties:
                       fsType:
                         description: |-
@@ -6586,7 +6583,7 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        The volume will be mounted read-only (ro).
                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
@@ -6758,8 +6755,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_outputs.yaml
@@ -4237,6 +4237,12 @@ spec:
                     description: Limit the maximum number of Chunks in the filesystem
                       for the current output logical destination.
                     type: string
+                  workers:
+                    description: Enables dedicated thread(s) for this output. Default
+                      value is set since version 1.8.13. For previous versions is
+                      0.
+                    format: int32
+                    type: integer
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/charts/fluent-operator-fluentd-crds/CHANGELOG.md
+++ b/charts/fluent-operator-fluentd-crds/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## [UNRELEASED]
 
+## [v4.1.0] - 2026-05-21
+
+### Changed
+
+- Updates to CRDs for fluent-operator v3.8.0 compatibility
+
 ## [v4.0.0] - 2026-04-19
 
 ### Changed
@@ -24,4 +30,5 @@
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator-crds-fluentd
+[v4.1.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-operator-crds-fluentd-4.1.0
 [v4.0.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-operator-crds-fluentd-4.0.0

--- a/charts/fluent-operator-fluentd-crds/Chart.yaml
+++ b/charts/fluent-operator-fluentd-crds/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: fluent-operator-fluentd-crds
 description: Custom Resource Definitions (CRDs) for Fluentd. Provides full Helm lifecycle management for all Fluentd CRDs used by Fluent Operator.
 type: application
-version: 4.0.0
+version: 4.1.0
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
-appVersion: 3.7.0
+appVersion: 3.8.0
 keywords:
   - logging
   - fluentd

--- a/charts/fluent-operator-fluentd-crds/README.md
+++ b/charts/fluent-operator-fluentd-crds/README.md
@@ -1,6 +1,6 @@
 # fluent-operator-fluentd-crds
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.7.0](https://img.shields.io/badge/AppVersion-3.7.0-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
 
 Custom Resource Definitions (CRDs) for Fluentd. Provides full Helm lifecycle management for all Fluentd CRDs used by Fluent Operator.
 
@@ -25,7 +25,7 @@ Custom Resource Definitions (CRDs) for Fluentd. Provides full Helm lifecycle man
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install fluent-operator-fluentd-crds oci://ghcr.io/fluent/helm-charts/fluent-operator-fluentd-crds --version 4.0.0
+helm upgrade --install fluent-operator-fluentd-crds oci://ghcr.io/fluent/helm-charts/fluent-operator-fluentd-crds --version 4.1.0
 ```
 
 #### Verification
@@ -33,7 +33,7 @@ helm upgrade --install fluent-operator-fluentd-crds oci://ghcr.io/fluent/helm-ch
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-operator-fluentd-crds:4.0.0
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-operator-fluentd-crds:4.1.0
 ```
 
 ### Non-OCI Repository
@@ -42,7 +42,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add fluent https://fluent.github.io/helm-charts/
-helm upgrade --install fluent-operator-fluentd-crds fluent/fluent-operator-fluentd-crds --version 4.0.0
+helm upgrade --install fluent-operator-fluentd-crds fluent/fluent-operator-fluentd-crds --version 4.1.0
 ```
 
 ## Values

--- a/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_clusterfluentdconfigs.yaml
+++ b/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_clusterfluentdconfigs.yaml
@@ -189,6 +189,18 @@ spec:
                 - record
                 - batch
                 type: string
+              pluginSortOrder:
+                default: lexicographic
+                description: |-
+                  PluginSortOrder controls how child plugins within a label section are
+                  ordered by their @id. "lexicographic" (default) preserves the original
+                  string-comparison behaviour. "index" switches to numeric-aware ordering
+                  so that a CR with more than nine plugins renders in definition order
+                  (e.g. plugin-2 before plugin-10).
+                enum:
+                - lexicographic
+                - index
+                type: string
               stickyTags:
                 description: |-
                   Sticky tags will match only one record from an event stream. The same tag will be treated the same way.

--- a/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_clusteroutputs.yaml
@@ -573,6 +573,13 @@ spec:
                     elasticsearch:
                       description: out_es plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -869,6 +876,13 @@ spec:
                     elasticsearchDataStream:
                       description: out_es datastreams plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -2195,8 +2209,8 @@ spec:
                             the rollover index to be created (default: default)'
                           type: string
                         bulkMessageRequestThreshold:
-                          description: 'Optional, Configure bulk_message request splitting
-                            threshold size (default: -1 unlimited)'
+                          description: 'Optional, Configure bulk_message_request_threshold
+                            splitting threshold size (default: -1 unlimited)'
                           format: int32
                           type: integer
                         caFile:

--- a/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_fluentdconfigs.yaml
+++ b/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_fluentdconfigs.yaml
@@ -326,6 +326,18 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              pluginSortOrder:
+                default: lexicographic
+                description: |-
+                  PluginSortOrder controls how child plugins within a label section are
+                  ordered by their @id. "lexicographic" (default) preserves the original
+                  string-comparison behaviour. "index" switches to numeric-aware ordering
+                  so that a CR with more than nine plugins renders in definition order
+                  (e.g. plugin-2 before plugin-10).
+                enum:
+                - lexicographic
+                - index
+                type: string
               stickyTags:
                 description: |-
                   Sticky tags will match only one record from an event stream. The same tag will be treated the same way.

--- a/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_fluentds.yaml
@@ -1505,7 +1505,6 @@ spec:
                       procMount denotes the type of proc mount to use for the containers.
                       The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
@@ -4030,7 +4029,7 @@ spec:
                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                      The volume will be mounted read-only (ro).
                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                     properties:
@@ -4196,8 +4195,7 @@ spec:
                     description: |-
                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                      is on.
+                      are redirected to the pxd.portworx.com CSI driver.
                     properties:
                       fsType:
                         description: |-
@@ -7012,7 +7010,7 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        The volume will be mounted read-only (ro).
                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
@@ -7184,8 +7182,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-

--- a/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator-fluentd-crds/templates/fluentd.fluent.io_outputs.yaml
@@ -573,6 +573,13 @@ spec:
                     elasticsearch:
                       description: out_es plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -869,6 +876,13 @@ spec:
                     elasticsearchDataStream:
                       description: out_es datastreams plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -2195,8 +2209,8 @@ spec:
                             the rollover index to be created (default: default)'
                           type: string
                         bulkMessageRequestThreshold:
-                          description: 'Optional, Configure bulk_message request splitting
-                            threshold size (default: -1 unlimited)'
+                          description: 'Optional, Configure bulk_message_request_threshold
+                            splitting threshold size (default: -1 unlimited)'
                           format: int32
                           type: integer
                         caFile:

--- a/charts/fluent-operator/CHANGELOG.md
+++ b/charts/fluent-operator/CHANGELOG.md
@@ -14,6 +14,18 @@
 
 ## [UNRELEASED]
 
+## [v4.1.0] - 2026-05-21
+
+### Added
+
+- Operator deployment now includes configurable liveness and readiness probes (hitting `/healthz` and `/readyz`) ([#1956](https://github.com/fluent/fluent-operator/pull/1956))
+
+### Changed
+
+- Hardened default `podSecurityContext` and `securityContext` for the operator: `runAsNonRoot`, `runAsUser/Group 65532`, `readOnlyRootFilesystem`, drop `ALL` capabilities, `seccompProfile: RuntimeDefault` ([#1956](https://github.com/fluent/fluent-operator/pull/1956))
+- Bumped default Fluent Bit image tag to `v5.0.5` ([#1968](https://github.com/fluent/fluent-operator/pull/1968))
+- Bumped fluent-operator to v3.8.0
+
 ## [v4.0.0] - 2026-04-19
 
 ### Changed
@@ -24,4 +36,5 @@
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator
+[v4.1.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-operator-4.1.0
 [v4.0.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-operator-4.0.0

--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,9 +6,9 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 4.0.0
+version: 4.1.0
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
-appVersion: 3.7.0
+appVersion: 3.8.0
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg
 home: https://github.com/fluent/fluent-operator
 sources:

--- a/charts/fluent-operator/README.md
+++ b/charts/fluent-operator/README.md
@@ -1,6 +1,6 @@
 # fluent-operator
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 3.7.0](https://img.shields.io/badge/AppVersion-3.7.0-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
 
 Kubernetes operator for Fluent Bit and Fluentd—define collectors, pipelines, and outputs as custom resources.
 
@@ -28,7 +28,7 @@ Kubernetes operator for Fluent Bit and Fluentd—define collectors, pipelines, a
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install fluent-operator oci://ghcr.io/fluent/helm-charts/fluent-operator --version 4.0.0
+helm upgrade --install fluent-operator oci://ghcr.io/fluent/helm-charts/fluent-operator --version 4.1.0
 ```
 
 #### Verification
@@ -36,7 +36,7 @@ helm upgrade --install fluent-operator oci://ghcr.io/fluent/helm-charts/fluent-o
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-operator:4.0.0
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-operator:4.1.0
 ```
 
 ### Non-OCI Repository
@@ -45,7 +45,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add fluent https://fluent.github.io/helm-charts/
-helm upgrade --install fluent-operator fluent/fluent-operator --version 4.0.0
+helm upgrade --install fluent-operator fluent/fluent-operator --version 4.1.0
 ```
 
 ## Values
@@ -333,11 +333,11 @@ See [MIGRATION-v4.md](https://github.com/fluent/fluent-operator/blob/master/char
 helm repo update
 
 # Manually update CRDs first (Helm doesn't upgrade CRDs in crds/ directory)
-helm pull fluent/fluent-operator --version 4.0.0 --untar
+helm pull fluent/fluent-operator --version 4.1.0 --untar
 kubectl apply -f fluent-operator/crds/
 
 # Then upgrade the chart
-helm upgrade fluent-operator fluent/fluent-operator --version 4.0.0
+helm upgrade fluent-operator fluent/fluent-operator --version 4.1.0
 ```
 
 ----------------------------------------------

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -342,6 +342,16 @@ spec:
                   hotReload:
                     description: If true enable reloading via HTTP
                     type: boolean
+                  hotReloadEnsureThreadSafety:
+                    description: If true, preserve thread safety during hot reload
+                      by waiting for in-flight work to drain before reloading; this
+                      wait can be bounded by hotReloadTimeout.
+                    type: boolean
+                  hotReloadTimeout:
+                    description: Maximum time in seconds to wait for a hot reload
+                      to complete before aborting.
+                    format: int32
+                    type: integer
                   httpListen:
                     description: Address to listen
                     pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusterinputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusterinputs.yaml
@@ -351,6 +351,21 @@ spec:
                   kubeURL:
                     description: API Server end-point
                     type: string
+                  pauseOnChunksOverlimit:
+                    description: Specifies if the input plugin should be paused (stop
+                      ingesting new data) when the storage.max_chunks_up value is
+                      reached.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
+                  storageType:
+                    description: Specifies the buffering mechanism for use with the
+                      input plugin, requires storage.path to be set in the service.
+                    enum:
+                    - filesystem
+                    - memory
+                    type: string
                   tag:
                     description: Tag name associated to all records coming from this
                       plugin.

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4235,6 +4235,12 @@ spec:
                     description: Limit the maximum number of Chunks in the filesystem
                       for the current output logical destination.
                     type: string
+                  workers:
+                    description: Enables dedicated thread(s) for this output. Default
+                      value is set since version 1.8.13. For previous versions is
+                      0.
+                    format: int32
+                    type: integer
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_collectors.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_collectors.yaml
@@ -2821,7 +2821,7 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        The volume will be mounted read-only (ro).
                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
@@ -2993,8 +2993,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbitconfigs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbitconfigs.yaml
@@ -374,6 +374,16 @@ spec:
                   hotReload:
                     description: If true enable reloading via HTTP
                     type: boolean
+                  hotReloadEnsureThreadSafety:
+                    description: If true, preserve thread safety during hot reload
+                      by waiting for in-flight work to drain before reloading; this
+                      wait can be bounded by hotReloadTimeout.
+                    type: boolean
+                  hotReloadTimeout:
+                    description: Maximum time in seconds to wait for a hot reload
+                      to complete before aborting.
+                    format: int32
+                    type: integer
                   httpListen:
                     description: Address to listen
                     pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -1041,7 +1041,6 @@ spec:
                       procMount denotes the type of proc mount to use for the containers.
                       The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
@@ -2486,7 +2485,6 @@ spec:
                             procMount denotes the type of proc mount to use for the containers.
                             The default value is Default which uses the container runtime defaults for
                             readonly paths and masked paths.
-                            This requires the ProcMountType feature flag to be enabled.
                             Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
@@ -4099,7 +4097,7 @@ spec:
                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                      The volume will be mounted read-only (ro).
                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                     properties:
@@ -4265,8 +4263,7 @@ spec:
                     description: |-
                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                      is on.
+                      are redirected to the pxd.portworx.com CSI driver.
                     properties:
                       fsType:
                         description: |-
@@ -6584,7 +6581,7 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        The volume will be mounted read-only (ro).
                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
@@ -6756,8 +6753,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_outputs.yaml
@@ -4235,6 +4235,12 @@ spec:
                     description: Limit the maximum number of Chunks in the filesystem
                       for the current output logical destination.
                     type: string
+                  workers:
+                    description: Enables dedicated thread(s) for this output. Default
+                      value is set since version 1.8.13. For previous versions is
+                      0.
+                    format: int32
+                    type: integer
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/charts/fluent-operator/crds/fluentd.fluent.io_clusterfluentdconfigs.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_clusterfluentdconfigs.yaml
@@ -187,6 +187,18 @@ spec:
                 - record
                 - batch
                 type: string
+              pluginSortOrder:
+                default: lexicographic
+                description: |-
+                  PluginSortOrder controls how child plugins within a label section are
+                  ordered by their @id. "lexicographic" (default) preserves the original
+                  string-comparison behaviour. "index" switches to numeric-aware ordering
+                  so that a CR with more than nine plugins renders in definition order
+                  (e.g. plugin-2 before plugin-10).
+                enum:
+                - lexicographic
+                - index
+                type: string
               stickyTags:
                 description: |-
                   Sticky tags will match only one record from an event stream. The same tag will be treated the same way.

--- a/charts/fluent-operator/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -571,6 +571,13 @@ spec:
                     elasticsearch:
                       description: out_es plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -867,6 +874,13 @@ spec:
                     elasticsearchDataStream:
                       description: out_es datastreams plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -2193,8 +2207,8 @@ spec:
                             the rollover index to be created (default: default)'
                           type: string
                         bulkMessageRequestThreshold:
-                          description: 'Optional, Configure bulk_message request splitting
-                            threshold size (default: -1 unlimited)'
+                          description: 'Optional, Configure bulk_message_request_threshold
+                            splitting threshold size (default: -1 unlimited)'
                           format: int32
                           type: integer
                         caFile:

--- a/charts/fluent-operator/crds/fluentd.fluent.io_fluentdconfigs.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_fluentdconfigs.yaml
@@ -324,6 +324,18 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              pluginSortOrder:
+                default: lexicographic
+                description: |-
+                  PluginSortOrder controls how child plugins within a label section are
+                  ordered by their @id. "lexicographic" (default) preserves the original
+                  string-comparison behaviour. "index" switches to numeric-aware ordering
+                  so that a CR with more than nine plugins renders in definition order
+                  (e.g. plugin-2 before plugin-10).
+                enum:
+                - lexicographic
+                - index
+                type: string
               stickyTags:
                 description: |-
                   Sticky tags will match only one record from an event stream. The same tag will be treated the same way.

--- a/charts/fluent-operator/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_fluentds.yaml
@@ -1503,7 +1503,6 @@ spec:
                       procMount denotes the type of proc mount to use for the containers.
                       The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
@@ -4028,7 +4027,7 @@ spec:
                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                      The volume will be mounted read-only (ro).
                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                     properties:
@@ -4194,8 +4193,7 @@ spec:
                     description: |-
                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                      is on.
+                      are redirected to the pxd.portworx.com CSI driver.
                     properties:
                       fsType:
                         description: |-
@@ -7010,7 +7008,7 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        The volume will be mounted read-only (ro).
                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
@@ -7182,8 +7180,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-

--- a/charts/fluent-operator/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_outputs.yaml
@@ -571,6 +571,13 @@ spec:
                     elasticsearch:
                       description: out_es plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -867,6 +874,13 @@ spec:
                     elasticsearchDataStream:
                       description: out_es datastreams plugin
                       properties:
+                        bulkMessageRequestThreshold:
+                          description: |-
+                            Optional, Configure bulk_message_request_threshold splitting threshold size.
+                            Default value is -1 (unlimited).
+                            If a bulk message exceeds this threshold, the request is split into multiple smaller requests.
+                          format: int32
+                          type: integer
                         caFile:
                           description: Optional, Absolute path to CA certificate file
                           type: string
@@ -2193,8 +2207,8 @@ spec:
                             the rollover index to be created (default: default)'
                           type: string
                         bulkMessageRequestThreshold:
-                          description: 'Optional, Configure bulk_message request splitting
-                            threshold size (default: -1 unlimited)'
+                          description: 'Optional, Configure bulk_message_request_threshold
+                            splitting threshold size (default: -1 unlimited)'
                           format: int32
                           type: integer
                         caFile:

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -55,6 +55,14 @@ spec:
           {{- with .Values.operator.disableComponentControllers }}
           - --disable-component-controllers={{ . }}
           {{- end }}
+        {{- with .Values.operator.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.operator.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: env
           mountPath: /fluent-operator

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -34,7 +34,13 @@ operator:
   priorityClassName: ""
   # -- Pod security context for Fluent Operator
   # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
   rbac:
     # -- Specifies whether to create the ClusterRole and ClusterRoleBinding
     create: true
@@ -48,7 +54,36 @@ operator:
     additionalRules: []
   # -- Container security context for Fluent Operator container
   # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-  securityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Liveness probe for Fluent Operator
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 8081
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # -- Readiness probe for Fluent Operator
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: 8081
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
   # -- Fluent Operator resource requests and limits
   resources:
     limits:
@@ -156,7 +191,7 @@ fluentbit:
     repository: fluent/fluent-operator/fluent-bit
     # -- Fluent Bit image tag
     # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-bit
-    tag: "5.0.2"
+    tag: "5.0.5"
 
   # -- Fluent Bit resource requests and limits. You can adjust it based on the log volume.
   # If you do want to specify resources, adjust them as necessary


### PR DESCRIPTION
## Summary

Syncs all three Fluent Operator charts from [fluent/fluent-operator v3.8.0](https://github.com/fluent/fluent-operator/releases/tag/v3.8.0):

| Chart | Old version | New version |
|---|---|---|
| `fluent-operator` | 4.0.0 | 4.1.0 |
| `fluent-operator-fluent-bit-crds` | 4.0.0 | 4.1.0 |
| `fluent-operator-fluentd-crds` | 4.0.0 | 4.1.0 |

### `fluent-operator`

- **Added:** configurable liveness and readiness probes for the operator deployment ([#1956](https://github.com/fluent/fluent-operator/pull/1956))
- **Changed:** hardened default `podSecurityContext` and `securityContext` (`runAsNonRoot`, `runAsUser/Group 65532`, `readOnlyRootFilesystem`, drop `ALL` capabilities, `seccompProfile: RuntimeDefault`) ([#1956](https://github.com/fluent/fluent-operator/pull/1956))
- **Changed:** bumped default Fluent Bit image tag to `v5.0.5` ([#1968](https://github.com/fluent/fluent-operator/pull/1968))
- **Changed:** updated CRDs (see below)

### `fluent-operator-fluent-bit-crds`

- **Added:** `ClusterFluentBitConfig` / `FluentBitConfig`: `hotReloadEnsureThreadSafety` and `hotReloadTimeout` fields ([#1926](https://github.com/fluent/fluent-operator/pull/1926))
- **Added:** `ClusterInput`: `storageType` and `pauseOnChunksOverlimit` fields for the Kubernetes events input plugin ([#1853](https://github.com/fluent/fluent-operator/pull/1853))
- **Added:** `ClusterOutput` / `Output`: `bulkMessageRequestThreshold` for the Elasticsearch output plugin ([#1946](https://github.com/fluent/fluent-operator/pull/1946))
- **Added:** `ClusterOutput` / `Output`: `workers` field for the syslog output plugin ([#1874](https://github.com/fluent/fluent-operator/pull/1874))
- **Changed:** minor upstream Kubernetes API spec description updates across several CRDs

### `fluent-operator-fluentd-crds`

- **Added:** `ClusterFluentdConfig` / `FluentdConfig`: `pluginSortOrder` field to control plugin `@id` sort order ([#1927](https://github.com/fluent/fluent-operator/pull/1927))
- **Changed:** minor upstream Kubernetes API spec description updates across several CRDs

## Test plan

- [ ] `helm lint charts/fluent-operator`
- [ ] `helm lint charts/fluent-operator-fluent-bit-crds`
- [ ] `helm lint charts/fluent-operator-fluentd-crds`
- [ ] Verify `appVersion: 3.8.0` and `version: 4.1.0` in all three `Chart.yaml` files

Made with [Cursor](https://cursor.com)