### PR TITLE
chore(fluent-operator) Add cw-Guo to fluent-operator CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 /charts/fluent-bit/              @stevehipwell @patrick-stephens @edsiper @naseemkullah
 /charts/fluent-bit-aggregator/   @stevehipwell @patrick-stephens
 /charts/fluent-bit-collector/    @stevehipwell @patrick-stephens
-/charts/fluent-operator/         @benjaminhuo @wanjunlei @wenchajun @marcofranssen @joshuabaird
+/charts/fluent-operator/         @benjaminhuo @wanjunlei @wenchajun @marcofranssen @joshuabaird @cw-Guo
 
 /.github/workflows/              @patrick-stephens @stevehipwell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,12 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*                                @patrick-stephens @stevehipwell
+*                                             @patrick-stephens @stevehipwell
 
-/charts/fluent-bit/              @stevehipwell @patrick-stephens @edsiper @naseemkullah
-/charts/fluent-bit-aggregator/   @stevehipwell @patrick-stephens
-/charts/fluent-bit-collector/    @stevehipwell @patrick-stephens
-/charts/fluent-operator/         @benjaminhuo @wanjunlei @wenchajun @marcofranssen @joshuabaird @cw-Guo
+/charts/fluent-bit/                           @stevehipwell @patrick-stephens @edsiper @naseemkullah
+/charts/fluent-bit-aggregator/                @stevehipwell @patrick-stephens
+/charts/fluent-bit-collector/                 @stevehipwell @patrick-stephens
+/charts/fluent-operator/                      @benjaminhuo @wanjunlei @wenchajun @marcofranssen @joshuabaird @cw-Guo
+/charts/fluent-operator-fluent-bit-crds/      @benjaminhuo @wanjunlei @wenchajun @marcofranssen @joshuabaird @cw-Guo
+/charts/fluent-operator-fluentd-crds/         @benjaminhuo @wanjunlei @wenchajun @marcofranssen @joshuabaird @cw-Guo
 
-/.github/workflows/              @patrick-stephens @stevehipwell
+/.github/workflows/                           @patrick-stephens @stevehipwell


### PR DESCRIPTION
@cw-Guo is a fluent-operator maintainer and thus should be able to approve PR's related to the fluent-operator helm charts.

Also adding CODEOWNERS for the fluent-operator CRD charts.