### PR TITLE
fix(fluent-bit): align `app.kubernetes.io/version` label with image tag

### DIFF
--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Set the `app.kubernetes.io/version` label to the resolved image tag when `image.tag` is overridden, falling back to the chart `appVersion` (including the `-` sentinel), so the label reflects the image actually deployed.
+
 ## [v0.57.6] - 2026-05-22
 
 ### Changed

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - fluent-bit
   - fluentd
-version: 0.57.6
+version: 0.57.7
 appVersion: 5.0.6
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
 home: https://fluentbit.io/

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -1,6 +1,6 @@
 # fluent-bit
 
-![Version: 0.57.6](https://img.shields.io/badge/Version-0.57.6-informational?style=flat-square) ![AppVersion: 5.0.6](https://img.shields.io/badge/AppVersion-5.0.6-informational?style=flat-square)
+![Version: 0.57.7](https://img.shields.io/badge/Version-0.57.7-informational?style=flat-square) ![AppVersion: 5.0.6](https://img.shields.io/badge/AppVersion-5.0.6-informational?style=flat-square)
 
 Fast and lightweight log processor and forwarder for Linux, OSX and BSD family operating systems.
 
@@ -26,7 +26,7 @@ Fast and lightweight log processor and forwarder for Linux, OSX and BSD family o
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --version 0.57.6
+helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --version 0.57.7
 ```
 
 #### Verification
@@ -34,7 +34,7 @@ helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-bit:0.57.6
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-bit:0.57.7
 ```
 
 ### Non-OCI Repository
@@ -43,7 +43,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add fluent https://fluent.github.io/helm-charts/
-helm upgrade --install fluent-bit fluent/fluent-bit --version 0.57.6
+helm upgrade --install fluent-bit fluent/fluent-bit --version 0.57.7
 ```
 
 ## Values

--- a/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/fluent-bit/templates/_helpers.tpl
@@ -32,13 +32,26 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Application version used for the app.kubernetes.io/version label.
+Uses the overridden image tag to match the image actually deployed, falling back
+to the chart appVersion when the tag is unset or set to the "-" sentinel.
+*/}}
+{{- define "fluent-bit.version" -}}
+{{- if or (empty .Values.image.tag) (eq "-" (toString .Values.image.tag)) -}}
+{{- .Chart.AppVersion -}}
+{{- else -}}
+{{- .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "fluent-bit.labels" -}}
 helm.sh/chart: {{ include "fluent-bit.chart" . }}
 {{ include "fluent-bit.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- with (include "fluent-bit.version" .) }}
+app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.testFramework.namespace }}
   labels:
     helm.sh/chart: {{ include "fluent-bit.chart" . }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ include "fluent-bit.version" . | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     helm.sh/hook: test


### PR DESCRIPTION
## What this does

The `app.kubernetes.io/version` label is hardcoded to `.Chart.AppVersion` in
`fluent-bit.labels`. When a user overrides `image.tag`, the deployed image and
the version label diverge — the label keeps reporting the chart's `appVersion`
while the pod runs the overridden tag.

This change resolves the label to the image actually deployed via a new
`fluent-bit.version` helper that returns `image.tag` when set, and falls back to
`.Chart.AppVersion` when the tag is unset or the `-` sentinel is used (mirroring
the existing `fluent-bit.image` tag handling). The helper is also used by the
test-connection pod for consistency.

## Behaviour

| `image.tag` | `app.kubernetes.io/version` |
| --- | --- |
| unset (default) | `.Chart.AppVersion` (unchanged) |
| `"-"` (digest-only) | `.Chart.AppVersion` |
| e.g. `4.0.8` | `4.0.8` |

Default behaviour is unchanged; the label only changes when `image.tag` is
overridden.

## Checklist

- [x] CHANGELOG.md entry added under `[UNRELEASED]`
- [x] Chart `version` bumped (0.57.6 → 0.57.7)
- [x] README regenerated (version bump only; no values changes)
- [x] `helm lint` passes
- [x] Commits signed off (DCO)

Closes #<issue-number>