### PR TITLE
fix(fluent-bit-collector): only mount the data volume when storage.enabled

### DIFF
--- a/charts/fluent-bit-collector/CHANGELOG.md
+++ b/charts/fluent-bit-collector/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Only mount the `data` volume when `storage.enabled` is `true`. The template previously checked `.Values.storage` (a map that is always truthy), so the volume was mounted even when storage was disabled. ([#732](https://github.com/fluent/helm-charts/pull/732)) _@yugstar_
+
 ## [v1.0.9] - 2026-07-06
 
 ### Changed

--- a/charts/fluent-bit-collector/templates/daemonset.yaml
+++ b/charts/fluent-bit-collector/templates/daemonset.yaml
@@ -122,7 +122,7 @@ spec:
               mountPath: {{ .mountPath }}
               readOnly: true
           {{- end }}
-          {{- if .Values.storage }}
+          {{- if .Values.storage.enabled }}
             - name: data
               mountPath: /fluent-bit/data
               readOnly: false
@@ -183,7 +183,7 @@ spec:
           hostPath:
             {{- toYaml .hostPath | nindent 12 }}
       {{- end }}
-      {{- if .Values.storage }}
+      {{- if .Values.storage.enabled }}
         - name: data
           hostPath:
             path: {{ .Values.storage.hostPath }}


### PR DESCRIPTION
## Description

The `fluent-bit-collector` DaemonSet guarded the `data` volume and volumeMount with `{{- if .Values.storage }}`. Since `.Values.storage` is always a non-empty map (it has `enabled` and `hostPath` keys), the condition was always true, so the writeable hostPath `data` volume was mounted **even when `storage.enabled: false`** (the default).

On clusters that restrict writeable hostPath access (restricted Pod Security Standards / hardened setups), this could block the pod from starting. A commenter confirmed the issue is still present on `main`.

This changes both guards to `{{- if .Values.storage.enabled }}`, matching the storage-args guard already used elsewhere in the same template.

## Verification

- `helm template` (default, `storage.enabled=false`) → no `data` volume/volumeMount rendered (volumes are `config`, `machine-id`, `logs` only).
- `--set storage.enabled=true` → `data` volume present (unchanged behaviour when storage is enabled).
- `helm lint` passes. Chart version bumped 1.0.7 → 1.0.8 and the README version references updated accordingly.

Closes #699
