### PR TITLE
fix(fluentd): let the HPA own spec.replicas on the Deployment

### DIFF
--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - Fix test connection pod to actually run so CI can pass. ([#720](https://github.com/fluent/helm-charts/pull/720)) @stevehipwell
+- Don't render `spec.replicas` on the _Deployment_ when `autoscaling.enabled` is `true` or `replicaCount` is unset, so the _HorizontalPodAutoscaler_ owns the replica count. ([#745](https://github.com/fluent/helm-charts/pull/745)) @ranyhb
 
 ## [v0.5.3] - 2025-05-05
 

--- a/charts/fluentd/templates/deployment.yaml
+++ b/charts/fluentd/templates/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and (not .Values.autoscaling.enabled) (ne .Values.replicaCount nil) }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- with .Values.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Closes #744.

## What this fixes

`templates/hpa.yaml` is rendered whenever `kind` is `Deployment` and `autoscaling.enabled` is `true`, but `templates/deployment.yaml` sets `spec.replicas` unconditionally. The chart therefore ships two objects that drive the same field: `kube-controller-manager` owns it through the `scale` subresource, and every `helm upgrade` (or GitOps/IaC apply) pushes it back to `replicaCount`, after which the HPA walks it back down again.

`values.yaml` also ships `replicaCount` commented out, so a `kind: Deployment` install that doesn't set it renders a **null** replica count — declared, re-asserted on every apply, and impossible to hand to an external autoscaler.

## How

One guard in `templates/deployment.yaml`:

```gotemplate
spec:
  {{- if and (not .Values.autoscaling.enabled) (ne .Values.replicaCount nil) }}
  replicas: {{ .Values.replicaCount }}
  {{- end }}
```

This is the pattern the other charts that ship an HPA already use — `ingress-nginx` guards on `autoscaling.enabled`/`keda.enabled`, `istio/gateway` guards on `autoscaling.enabled` plus a non-nil `replicaCount`, and `istiod` never renders the field at all.

## Rendered behaviour

| `--set` | before | after |
|---|---|---|
| `kind=Deployment` | `replicas:` (null) | field omitted |
| `kind=Deployment,replicaCount=5` | `replicas: 5` | `replicas: 5` (unchanged) |
| `kind=Deployment,autoscaling.enabled=true` | `replicas:` (null) + HPA | field omitted + HPA |
| `kind=Deployment,replicaCount=5,autoscaling.enabled=true` | `replicas: 5` + HPA | field omitted + HPA |

`kind: DaemonSet` (the default) and `kind: StatefulSet` render identically before and after — 11 documents each, byte for byte.

## Scope

`templates/statefulset.yaml` carries the same unguarded line, but the chart's HPA is gated on `eq .Values.kind "Deployment"`, so a StatefulSet never gets one from this chart. Guarding it there would change the replica count for existing StatefulSet users without fixing a conflict, so it is deliberately left alone.

No `values.yaml` change, so no helm-docs regeneration is needed.

## Checklist

- [x] `CHANGELOG.md` entry added under `[UNRELEASED]`
- [x] Commit signed off (DCO)
- [x] Single chart
- [x] Closes the issue