### PR TITLE
feat(fluentd): add topologySpreadConstraints value

### DIFF
--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Added
 
 - Add `variantVersion` value to specify the version of the variant to use. ([#720](https://github.com/fluent/helm-charts/pull/720)) @stevehipwell
+- Add `topologySpreadConstraints` value to spread pods across zones or nodes. ([#747](https://github.com/fluent/helm-charts/pull/747)) @ranyhb
 
 ### Changed
 

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -120,6 +120,7 @@ helm upgrade --install fluentd fluent/fluentd --version 0.5.3
 | serviceAccount.name | string | `nil` |  |
 | terminationGracePeriodSeconds | string | `nil` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
 | updateStrategy | object | `{}` |  |
 | variant | string | `"elasticsearch7"` |  |
 | variantVersion | string | `"1.6"` |  |

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -127,4 +127,8 @@ affinity:
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end -}}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -132,6 +132,17 @@ tolerations: []
 ##
 affinity: {}
 
+## Topology spread constraints, only applicable for Deployment or StatefulSet
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+##
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: topology.kubernetes.io/zone
+#   whenUnsatisfiable: ScheduleAnyway
+#   labelSelector:
+#     matchLabels:
+#       app.kubernetes.io/name: fluentd
+
 ## Annotations to be added to fluentd DaemonSet/Deployment
 ##
 annotations: {}


### PR DESCRIPTION
Closes #746.

## What this adds

The chart exposes `nodeSelector`, `affinity`, `tolerations` and `priorityClassName`, but there is no way to set pod topology spread constraints. With `kind: Deployment` or `kind: StatefulSet` that means replicas can't be spread across zones or nodes from chart values — `podAntiAffinity` can only forbid or prefer co-location, it can't express a bounded skew with `whenUnsatisfiable: ScheduleAnyway`.

## How

One block in `templates/_pod.tpl`, next to the existing scheduling values:

```gotemplate
{{- with .Values.topologySpreadConstraints }}
topologySpreadConstraints:
  {{- toYaml . | nindent 2 }}
{{- end }}
```

plus `topologySpreadConstraints: []` in `values.yaml` with a commented example.

## No change for existing users

Rendered output is **byte-identical** to `main` when the value is unset, for all three kinds:

```console
$ for k in DaemonSet Deployment StatefulSet; do
    helm template t . --set kind=$k | diff -q - <(git stash; helm template t . --set kind=$k; git stash pop)
  done
DaemonSet    identical
Deployment   identical
StatefulSet  identical
```

With it set:

```yaml
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app.kubernetes.io/name: fluentd
          maxSkew: 1
          topologyKey: topology.kubernetes.io/zone
          whenUnsatisfiable: ScheduleAnyway
```

Because it lives in the shared pod template it applies to all three kinds; it is only meaningful for `Deployment`/`StatefulSet`, which the values comment says.

## Checklist

- [x] `values.yaml` documented with a helm-docs comment and the `README.md` values table updated (`helm-docs` isn't available locally, so the row was added by hand in the alphabetical position it generates — please re-run `just docs` if it differs)
- [x] `CHANGELOG.md` entry added under `[UNRELEASED]`
- [x] Commit signed off (DCO)
- [x] Single chart
- [x] Closes the issue

Related: #745, the other fluentd fix I have open — independent of this one.